### PR TITLE
fix: fixed kd ratio formula to avoid infinity

### DIFF
--- a/src/components/pgcr/player-row.tsx
+++ b/src/components/pgcr/player-row.tsx
@@ -169,7 +169,7 @@ export default function PlayerRow({ player }: PlayerRowProps) {
                             "text-zinc-500": !player.completed
                         }
                     )}>
-                    {(stats.kills + stats.deaths === 0 ? 0 : stats.kills / stats.deaths).toFixed(2)}
+                    {(stats.deaths === 0 ? stats.kills : stats.kills / stats.deaths).toFixed(2)}
                 </div>
                 <div
                     className={cn("text-primary/85 text-center", {


### PR DESCRIPTION
**What this fix does:**

- Fixed an issue where KD ratio is set to Infinity if player has no deaths


I noticed this little issue while using the website and i was a little bit triggered by the Infinity in the player row.

Image for reference:
![image](https://github.com/user-attachments/assets/6caafb7d-32f6-4bfb-8e1e-6084f01969fd)
