### PR TITLE
fix: restored old gm report favicon

### DIFF
--- a/src/components/profile/user/CommunityProfiles..tsx
+++ b/src/components/profile/user/CommunityProfiles..tsx
@@ -29,7 +29,7 @@ export function CommunityProfiles() {
             <Profile
                 title="GM Report"
                 url={`https://gm.report/${props.destinyMembershipId}`}
-                icon="https://gm.report/apple-icon-180x180.png"
+                icon="https://legacy.gm.report/apple-icon-180x180.png"
             />
             <Profile
                 title="Trials Report"


### PR DESCRIPTION
This pr restores the old gm report favicon.

Why?
Gm report recently got updated, and the old favicon was replaced with a newer svg only version, and currently the favicon is not visible in the user profile
<img width="375" height="90" alt="{10F15EAC-159F-4C36-BA8E-FAE08BC6B102}" src="https://github.com/user-attachments/assets/7dbaffab-0d03-49f0-a56a-4294a44f2556" />


Why are we using the legacy favicon instead of the new one ?
The new gm.report favicon has bad contrast with raidhub's CommunityProfiles component. 

Link to new gm.report favicon: https://gm.report/gmreport.svg
Link to legacy favicon: https://legacy.gm.report/apple-icon-180x180.png