### PR TITLE
Make entire leaderboard card clickable, not just timestamp

### DIFF
--- a/src/app/leaderboards/LeaderboardEntryComponent.tsx
+++ b/src/app/leaderboards/LeaderboardEntryComponent.tsx
@@ -2,7 +2,6 @@
 
 import Link from "next/link"
 import { useEffect, useMemo, useRef } from "react"
-import { OptionalWrapper } from "~/components/OptionalWrapper"
 import { useLocale } from "~/components/providers/LocaleManager"
 import { useQueryParams } from "~/hooks/util/useQueryParams"
 import { cn } from "~/lib/tw"
@@ -63,12 +62,21 @@ export const LeaderboardEntryComponent = ({
         <div
             ref={sm}
             className={cn(
-                "bg-card flex w-full flex-col items-center rounded border p-2 shadow-md transition-transform hover:scale-105 lg:flex-row lg:justify-between",
+                "bg-card relative flex w-full flex-col items-center rounded border p-2 shadow-md transition-transform hover:scale-105 lg:flex-row lg:justify-between",
                 { "max-w-[450px]": entry.type === "player" }
             )}
             style={targettedStyle}>
+            {entry.url && (
+                <Link
+                    href={entry.url}
+                    target={entry.url.startsWith("/") ? undefined : "_blank"}
+                    aria-label={`View details for ${value}`}
+                    className="absolute inset-0 rounded"
+                />
+            )}
+
             {/* Left side */}
-            <div className="flex-1">
+            <div className="pointer-events-none relative z-10 flex-1">
                 {/* Players */}
                 <div className="flex gap-4 p-2">
                     <div className="flex aspect-square min-w-5 flex-col justify-center text-lg">
@@ -88,19 +96,8 @@ export const LeaderboardEntryComponent = ({
                 </div>
             </div>
 
-            {/* Right side (link or additional info) */}
-            <OptionalWrapper
-                condition={entry.url}
-                wrapper={({ children, value }) => (
-                    <Link
-                        className="w-28 p-2 text-inherit"
-                        href={value}
-                        target={value.startsWith("/") ? undefined : "_blank"}>
-                        {children}
-                    </Link>
-                )}>
-                <div>{value}</div>
-            </OptionalWrapper>
+            {/* Right side (timestamp / value) */}
+            <div className="w-28 p-2">{value}</div>
         </div>
     )
 }

--- a/src/app/leaderboards/LeaderboardEntryPlayer.tsx
+++ b/src/app/leaderboards/LeaderboardEntryPlayer.tsx
@@ -16,6 +16,7 @@ export const LeaderboardEntryPlayerComponent = (player: LeaderboardEntryPlayer) 
             condition={player.url}
             wrapper={({ children, value }) => (
                 <Link
+                    className="pointer-events-auto"
                     style={{ color: "unset" }}
                     href={value}
                     target={value.startsWith("/") ? "" : "_blank"}>


### PR DESCRIPTION
## Summary

On the leaderboard pages (including world-first race team views), each PGCR card currently only navigates when the user clicks the small timestamp on the right. Clicks anywhere else on the card do nothing, even though the whole row visually reads as one tap target and already animates on hover.

This PR makes the entire card clickable, while keeping the nested player profile links individually clickable.

## Implementation

Standard "overlay link" pattern, applied in `LeaderboardEntryComponent.tsx`:

- The card becomes `position: relative`.
- An absolute-positioned `<Link>` is rendered as a sibling, covering the full card via `absolute inset-0`. This becomes the click target for the whole card.
- The inner content wrapper gets `relative z-10 pointer-events-none` so:
  - It sits above the overlay (so player links inside aren't covered).
  - Clicks on its background (gaps between players, padding, the right-side value area) fall through to the overlay.
- The right-side timestamp is no longer wrapped in its own `<Link>` (the overlay handles it now).
- Player profile links in `LeaderboardEntryPlayer.tsx` get `pointer-events-auto` so they override the parent's `pointer-events-none` and stay individually clickable.

This preserves cmd-click / middle-click / hover-to-see-URL / accessibility, and avoids invalid nested anchors.

The component is shared across player and team leaderboards, so the improvement applies everywhere a `LeaderboardEntryComponent` is used.

## Why draft

Opening as draft because I don't yet have a `RAIDHUB_API_KEY` for local dev — `bun dev` won't render populated leaderboards without one. Local checks (`bun lint`, `bun format`, `bunx tsc --noEmit`, dev-server compile) all pass, but I want to verify visual behavior on the Vercel preview before requesting review.

Will mark ready once I've clicked through the preview and confirmed the test plan below.

## Test plan

On a populated team leaderboard (e.g. `/leaderboards/team/salvations-edge/worldfirst`) and a player leaderboard:

- [ ] Clicking the timestamp on the right still navigates to the PGCR (regression check)
- [ ] Clicking anywhere else on the card (left padding, between players, right-side empty area) navigates to the PGCR
- [ ] Clicking a player's avatar or name navigates to that player's profile (nested link still works)
- [ ] Cmd-click on a card background opens the PGCR in a new tab
- [ ] Hovering shows the PGCR URL in the browser status bar (confirms it's a real anchor)
- [ ] Cards with no `entry.url` are unchanged (no overlay, no broken click target)