### PR TITLE
feat(pantheon): Pantheon 2.0 modes and sunset UX

### DIFF
--- a/src/app/leaderboards/individual/pantheon/[version]/[category]/page.tsx
+++ b/src/app/leaderboards/individual/pantheon/[version]/[category]/page.tsx
@@ -2,6 +2,7 @@ import { type Metadata } from "next"
 import { notFound } from "next/navigation"
 import { LeaderboardSSR } from "~/app/leaderboards/LeaderboardSSR"
 import { CloudflareActivitySplash } from "~/components/CloudflareImage"
+import { findPantheonVersionByPath } from "~/lib/manifest/pantheon"
 import { baseMetadata } from "~/lib/metadata"
 import { prefetchManifest } from "~/services/raidhub/prefetchRaidHubManifest"
 import {
@@ -25,17 +26,18 @@ const getDefinitions = (
     params: PantheonVersionLeaderboardDynamicParams["params"],
     manifest: RaidHubManifestResponse
 ) => {
-    const definition = Object.values(manifest.versionDefinitions).find(
-        data => data.associatedActivityId === 101 && data.path === params.version
-    )
+    const definition = findPantheonVersionByPath(manifest, params.version)
 
-    if (!definition) {
+    if (!definition?.associatedActivityId) {
         return notFound()
-    } else {
-        return {
-            definition,
-            categoryName: params.category[0].toUpperCase() + params.category.slice(1)
-        }
+    }
+
+    const activity = manifest.activityDefinitions[definition.associatedActivityId] ?? null
+
+    return {
+        definition,
+        activity,
+        categoryName: params.category[0].toUpperCase() + params.category.slice(1)
     }
 }
 
@@ -43,10 +45,11 @@ export async function generateMetadata({
     params
 }: PantheonVersionLeaderboardDynamicParams): Promise<Metadata> {
     const manifest = await prefetchManifest()
-    const { definition, categoryName } = getDefinitions(params, manifest)
+    const { definition, activity, categoryName } = getDefinitions(params, manifest)
+    const activityName = activity?.name ?? "The Pantheon"
 
-    const title = `The Pantheon: ${definition.name} ${categoryName} Completion Leaderboard`
-    const description = `View the Pantheon: ${
+    const title = `${activityName}: ${definition.name} ${categoryName} Completion Leaderboard`
+    const description = `View the ${activityName}: ${
         definition.name
     } ${categoryName.toLowerCase()} leaderboards`
 
@@ -74,16 +77,20 @@ export default async function Page({
     searchParams
 }: PantheonVersionLeaderboardDynamicParams) {
     const manifest = await prefetchManifest()
-    const { definition, categoryName } = getDefinitions(params, manifest)
+    const { definition, activity, categoryName } = getDefinitions(params, manifest)
 
     return (
         <Leaderboard
             heading={
                 <Splash
-                    tertiaryTitle="The Pantheon"
+                    tertiaryTitle={activity?.name ?? "The Pantheon"}
                     title={definition.name}
                     subtitle={`${categoryName} Leaderboard`}>
-                    <CloudflareActivitySplash activityId={definition.id} fill className="z-[-1]" />
+                    <CloudflareActivitySplash
+                        activityId={definition.associatedActivityId!}
+                        fill
+                        className="z-[-1]"
+                    />
                 </Splash>
             }
             hasPages

--- a/src/components/home/HomeBuckets.tsx
+++ b/src/components/home/HomeBuckets.tsx
@@ -264,14 +264,23 @@ function VersionFirstLinks() {
     )
 }
 
-function PantheonLinks() {
-    const { pantheonVersions, getVersionString, getUrlPathForVersion } = useRaidHubManifest()
+function PantheonModeLinks({
+    versions,
+    keyPrefix
+}: {
+    versions: readonly number[]
+    keyPrefix: string
+}) {
+    const { getVersionString, getUrlPathForVersion } = useRaidHubManifest()
+
+    if (!versions.length) return null
+
     return (
-        <div>
+        <>
             <h3 className="mb-2 text-lg font-bold">First Completions</h3>
             <ul>
-                {pantheonVersions.map(version => (
-                    <li key={`first-${version}`}>
+                {versions.map(version => (
+                    <li key={`${keyPrefix}-first-${version}`}>
                         <Link
                             href={`/leaderboards/team/pantheon/first/${getUrlPathForVersion(version)}`}
                             className="text-raidhub text-lg hover:underline">
@@ -282,8 +291,8 @@ function PantheonLinks() {
             </ul>
             <h3 className="mt-4 mb-2 text-lg font-bold">Full Clears</h3>
             <ul>
-                {pantheonVersions.map(version => (
-                    <li key={`clears-${version}`}>
+                {versions.map(version => (
+                    <li key={`${keyPrefix}-clears-${version}`}>
                         <Link
                             href={`/leaderboards/individual/pantheon/${getUrlPathForVersion(
                                 version
@@ -294,6 +303,22 @@ function PantheonLinks() {
                     </li>
                 ))}
             </ul>
+        </>
+    )
+}
+
+function PantheonLinks() {
+    const { activePantheonBossVersions, activeGauntletVersions } = useRaidHubManifest()
+
+    return (
+        <div>
+            <PantheonModeLinks versions={activePantheonBossVersions} keyPrefix="boss" />
+            {activeGauntletVersions.length > 0 && (
+                <div className="mt-4">
+                    <h3 className="mb-2 text-lg font-bold">Gauntlet</h3>
+                    <PantheonModeLinks versions={activeGauntletVersions} keyPrefix="gauntlet" />
+                </div>
+            )}
         </div>
     )
 }

--- a/src/components/home/HomeBuckets.tsx
+++ b/src/components/home/HomeBuckets.tsx
@@ -308,17 +308,11 @@ function PantheonModeLinks({
 }
 
 function PantheonLinks() {
-    const { activePantheonBossVersions, activeGauntletVersions } = useRaidHubManifest()
+    const { activePantheonBossVersions } = useRaidHubManifest()
 
     return (
         <div>
             <PantheonModeLinks versions={activePantheonBossVersions} keyPrefix="boss" />
-            {activeGauntletVersions.length > 0 && (
-                <div className="mt-4">
-                    <h3 className="mb-2 text-lg font-bold">Gauntlet</h3>
-                    <PantheonModeLinks versions={activeGauntletVersions} keyPrefix="gauntlet" />
-                </div>
-            )}
         </div>
     )
 }

--- a/src/components/home/HomeBuckets.tsx
+++ b/src/components/home/HomeBuckets.tsx
@@ -308,11 +308,17 @@ function PantheonModeLinks({
 }
 
 function PantheonLinks() {
-    const { activePantheonBossVersions } = useRaidHubManifest()
+    const { activePantheonBossVersions, activeGauntletVersions } = useRaidHubManifest()
 
     return (
         <div>
             <PantheonModeLinks versions={activePantheonBossVersions} keyPrefix="boss" />
+            {activeGauntletVersions.length > 0 && (
+                <div className="mt-4">
+                    <h3 className="mb-2 text-lg font-bold">Gauntlet</h3>
+                    <PantheonModeLinks versions={activeGauntletVersions} keyPrefix="gauntlet" />
+                </div>
+            )}
         </div>
     )
 }

--- a/src/components/profile/raids/PantheonLayout.tsx
+++ b/src/components/profile/raids/PantheonLayout.tsx
@@ -6,6 +6,30 @@ import { useRaidHubManifest } from "~/components/providers/RaidHubManifestManage
 import { type RaidHubInstanceForPlayer } from "~/services/raidhub/types"
 import { RaidCardContext } from "./RaidCardContext"
 
+const PantheonModeGrid = ({
+    modes,
+    instancesByMode,
+    isLoading,
+    isExpanded
+}: {
+    modes: readonly number[]
+    instancesByMode: Collection<number, Collection<string, RaidHubInstanceForPlayer>> | null
+    isLoading: boolean
+    isExpanded: boolean
+}) => (
+    <Grid as="section" $minCardWidth={325} $minCardWidthMobile={300} $fullWidth $relative>
+        {modes.toSorted((a, b) => b - a).map(mode => (
+            <RaidCardContext
+                key={mode}
+                activities={instancesByMode?.get(mode)}
+                isLoadingActivities={isLoading}
+                raidId={mode}>
+                <RaidCard leaderboardEntry={null} isExpanded={isExpanded} />
+            </RaidCardContext>
+        ))}
+    </Grid>
+)
+
 export const PantheonLayout = ({
     instances,
     isLoading,
@@ -15,7 +39,18 @@ export const PantheonLayout = ({
     isExpanded: boolean
     isLoading: boolean
 }) => {
-    const { pantheonVersions } = useRaidHubManifest()
+    const {
+        activeGauntletVersions,
+        activePantheonBossVersions,
+        gauntletVersions,
+        pantheonBossVersions,
+        isPantheonVersionSunset
+    } = useRaidHubManifest()
+
+    const activeModes = [...activeGauntletVersions, ...activePantheonBossVersions]
+    const historicalModes = [...gauntletVersions, ...pantheonBossVersions].filter(id =>
+        isPantheonVersionSunset(id)
+    )
 
     const instancesByMode = useMemo(() => {
         if (isLoading) return null
@@ -31,18 +66,26 @@ export const PantheonLayout = ({
     }, [instances, isLoading])
 
     return (
-        <Grid as="section" $minCardWidth={325} $minCardWidthMobile={300} $fullWidth $relative>
-            {pantheonVersions
-                .toSorted((a, b) => b - a)
-                .map(mode => (
-                    <RaidCardContext
-                        key={mode}
-                        activities={instancesByMode?.get(mode)}
-                        isLoadingActivities={isLoading}
-                        raidId={mode}>
-                        <RaidCard leaderboardEntry={null} isExpanded={isExpanded} />
-                    </RaidCardContext>
-                ))}
-        </Grid>
+        <div className="flex w-full flex-col gap-6">
+            <PantheonModeGrid
+                modes={activeModes}
+                instancesByMode={instancesByMode}
+                isLoading={isLoading}
+                isExpanded={isExpanded}
+            />
+            {historicalModes.length > 0 && (
+                <div>
+                    <h3 className="text-secondary mb-3 text-sm font-semibold tracking-wide uppercase">
+                        Historical Modes
+                    </h3>
+                    <PantheonModeGrid
+                        modes={historicalModes}
+                        instancesByMode={instancesByMode}
+                        isLoading={isLoading}
+                        isExpanded={isExpanded}
+                    />
+                </div>
+            )}
+        </div>
     )
 }

--- a/src/components/profile/raids/PantheonLayout.tsx
+++ b/src/components/profile/raids/PantheonLayout.tsx
@@ -41,11 +41,18 @@ export const PantheonLayout = ({
     isExpanded: boolean
     isLoading: boolean
 }) => {
-    const { activePantheonBossVersions, pantheonBossVersions, isPantheonVersionSunset } =
-        useRaidHubManifest()
+    const {
+        activeGauntletVersions,
+        activePantheonBossVersions,
+        gauntletVersions,
+        pantheonBossVersions,
+        isPantheonVersionSunset
+    } = useRaidHubManifest()
 
-    const activeModes = activePantheonBossVersions
-    const historicalModes = pantheonBossVersions.filter(id => isPantheonVersionSunset(id))
+    const activeModes = [...activeGauntletVersions, ...activePantheonBossVersions]
+    const historicalModes = [...gauntletVersions, ...pantheonBossVersions].filter(id =>
+        isPantheonVersionSunset(id)
+    )
 
     const instancesByMode = useMemo(() => {
         if (isLoading) return null

--- a/src/components/profile/raids/PantheonLayout.tsx
+++ b/src/components/profile/raids/PantheonLayout.tsx
@@ -18,15 +18,17 @@ const PantheonModeGrid = ({
     isExpanded: boolean
 }) => (
     <Grid as="section" $minCardWidth={325} $minCardWidthMobile={300} $fullWidth $relative>
-        {modes.toSorted((a, b) => b - a).map(mode => (
-            <RaidCardContext
-                key={mode}
-                activities={instancesByMode?.get(mode)}
-                isLoadingActivities={isLoading}
-                raidId={mode}>
-                <RaidCard leaderboardEntry={null} isExpanded={isExpanded} />
-            </RaidCardContext>
-        ))}
+        {modes
+            .toSorted((a, b) => b - a)
+            .map(mode => (
+                <RaidCardContext
+                    key={mode}
+                    activities={instancesByMode?.get(mode)}
+                    isLoadingActivities={isLoading}
+                    raidId={mode}>
+                    <RaidCard leaderboardEntry={null} isExpanded={isExpanded} />
+                </RaidCardContext>
+            ))}
     </Grid>
 )
 
@@ -39,18 +41,11 @@ export const PantheonLayout = ({
     isExpanded: boolean
     isLoading: boolean
 }) => {
-    const {
-        activeGauntletVersions,
-        activePantheonBossVersions,
-        gauntletVersions,
-        pantheonBossVersions,
-        isPantheonVersionSunset
-    } = useRaidHubManifest()
+    const { activePantheonBossVersions, pantheonBossVersions, isPantheonVersionSunset } =
+        useRaidHubManifest()
 
-    const activeModes = [...activeGauntletVersions, ...activePantheonBossVersions]
-    const historicalModes = [...gauntletVersions, ...pantheonBossVersions].filter(id =>
-        isPantheonVersionSunset(id)
-    )
+    const activeModes = activePantheonBossVersions
+    const historicalModes = pantheonBossVersions.filter(id => isPantheonVersionSunset(id))
 
     const instancesByMode = useMemo(() => {
         if (isLoading) return null

--- a/src/components/providers/RaidHubManifestManager.tsx
+++ b/src/components/providers/RaidHubManifestManager.tsx
@@ -2,13 +2,13 @@
 
 import { useQuery } from "@tanstack/react-query"
 import { createContext, useContext, useMemo, type ReactNode } from "react"
-import { getRaidHubApi } from "~/services/raidhub/common"
 import {
     findPantheonVersionByPath as findPantheonVersionByPathInManifest,
     getActivePantheonIds,
     getPantheonVersionsForActivities,
     isPantheonVersionSunset as isPantheonVersionSunsetInManifest
 } from "~/lib/manifest/pantheon"
+import { getRaidHubApi } from "~/services/raidhub/common"
 import type {
     ImageContentData,
     RaidHubActivityDefinition,
@@ -24,6 +24,8 @@ type ManifestContextData = RaidHubManifestResponse & {
     activePantheonVersions: readonly number[]
     pantheonBossVersions: readonly number[]
     activePantheonBossVersions: readonly number[]
+    gauntletVersions: readonly number[]
+    activeGauntletVersions: readonly number[]
     elevatedDifficulties: readonly number[]
     milestoneHashes: Map<number, RaidHubActivityDefinition>
     getVersionString(versionId: number): string
@@ -31,6 +33,7 @@ type ManifestContextData = RaidHubManifestResponse & {
     getUrlPathForActivity(activityId: number): string | null
     getUrlPathForVersion(versionId: number): string | null
     getActivePantheonActivityId(): number | null
+    isGauntletVersion(versionId: number): boolean
     isPantheonVersionSunset(versionId: number): boolean
     getDefinitionFromHash(hash: string | number): {
         activity: RaidHubActivityDefinition
@@ -49,7 +52,7 @@ export function RaidHubManifestManager(props: {
     children: ReactNode
     serverManifest: RaidHubManifestResponse
 }) {
-    const { data } = useQuery({
+    const { data } = useQuery<RaidHubManifestResponse>({
         queryKey: ["raidhub-manifest"],
         queryFn: () => getRaidHubApi("/manifest", null, null).then(res => res.response),
         initialData: props.serverManifest,
@@ -60,8 +63,15 @@ export function RaidHubManifestManager(props: {
         const activePantheonIds = getActivePantheonIds(data)
         const pantheonVersions = getPantheonVersionsForActivities(data, data.pantheonIds)
         const activePantheonVersions = getPantheonVersionsForActivities(data, activePantheonIds)
-        const pantheonBossVersions = pantheonVersions
-        const activePantheonBossVersions = activePantheonVersions
+        const gauntletVersions = data.gauntletVersionIds ?? []
+        const gauntletVersionSet = new Set(gauntletVersions)
+        const pantheonBossVersions = pantheonVersions.filter(id => !gauntletVersionSet.has(id))
+        const activeGauntletVersions = gauntletVersions.filter(
+            id => !isPantheonVersionSunsetInManifest(data, id)
+        )
+        const activePantheonBossVersions = activePantheonVersions.filter(
+            id => !gauntletVersionSet.has(id)
+        )
 
         return {
             ...data,
@@ -72,6 +82,8 @@ export function RaidHubManifestManager(props: {
             activePantheonVersions,
             pantheonBossVersions,
             activePantheonBossVersions,
+            gauntletVersions,
+            activeGauntletVersions,
             elevatedDifficulties: [3, 4],
             milestoneHashes: new Map(
                 Object.entries(data.activityDefinitions)
@@ -92,6 +104,9 @@ export function RaidHubManifestManager(props: {
             },
             getActivePantheonActivityId() {
                 return activePantheonIds[0] ?? null
+            },
+            isGauntletVersion(versionId) {
+                return gauntletVersionSet.has(versionId)
             },
             isPantheonVersionSunset(versionId) {
                 return isPantheonVersionSunsetInManifest(data, versionId)

--- a/src/components/providers/RaidHubManifestManager.tsx
+++ b/src/components/providers/RaidHubManifestManager.tsx
@@ -24,8 +24,6 @@ type ManifestContextData = RaidHubManifestResponse & {
     activePantheonVersions: readonly number[]
     pantheonBossVersions: readonly number[]
     activePantheonBossVersions: readonly number[]
-    gauntletVersions: readonly number[]
-    activeGauntletVersions: readonly number[]
     elevatedDifficulties: readonly number[]
     milestoneHashes: Map<number, RaidHubActivityDefinition>
     getVersionString(versionId: number): string
@@ -33,7 +31,6 @@ type ManifestContextData = RaidHubManifestResponse & {
     getUrlPathForActivity(activityId: number): string | null
     getUrlPathForVersion(versionId: number): string | null
     getActivePantheonActivityId(): number | null
-    isGauntletVersion(versionId: number): boolean
     isPantheonVersionSunset(versionId: number): boolean
     getDefinitionFromHash(hash: string | number): {
         activity: RaidHubActivityDefinition
@@ -63,15 +60,8 @@ export function RaidHubManifestManager(props: {
         const activePantheonIds = getActivePantheonIds(data)
         const pantheonVersions = getPantheonVersionsForActivities(data, data.pantheonIds)
         const activePantheonVersions = getPantheonVersionsForActivities(data, activePantheonIds)
-        const gauntletVersions = data.gauntletVersionIds ?? []
-        const gauntletVersionSet = new Set(gauntletVersions)
-        const pantheonBossVersions = pantheonVersions.filter(id => !gauntletVersionSet.has(id))
-        const activeGauntletVersions = gauntletVersions.filter(
-            id => !isPantheonVersionSunsetInManifest(data, id)
-        )
-        const activePantheonBossVersions = activePantheonVersions.filter(
-            id => !gauntletVersionSet.has(id)
-        )
+        const pantheonBossVersions = pantheonVersions
+        const activePantheonBossVersions = activePantheonVersions
 
         return {
             ...data,
@@ -82,8 +72,6 @@ export function RaidHubManifestManager(props: {
             activePantheonVersions,
             pantheonBossVersions,
             activePantheonBossVersions,
-            gauntletVersions,
-            activeGauntletVersions,
             elevatedDifficulties: [3, 4],
             milestoneHashes: new Map(
                 Object.entries(data.activityDefinitions)
@@ -104,9 +92,6 @@ export function RaidHubManifestManager(props: {
             },
             getActivePantheonActivityId() {
                 return activePantheonIds[0] ?? null
-            },
-            isGauntletVersion(versionId) {
-                return gauntletVersionSet.has(versionId)
             },
             isPantheonVersionSunset(versionId) {
                 return isPantheonVersionSunsetInManifest(data, versionId)

--- a/src/components/providers/RaidHubManifestManager.tsx
+++ b/src/components/providers/RaidHubManifestManager.tsx
@@ -3,6 +3,12 @@
 import { useQuery } from "@tanstack/react-query"
 import { createContext, useContext, useMemo, type ReactNode } from "react"
 import { getRaidHubApi } from "~/services/raidhub/common"
+import {
+    findPantheonVersionByPath as findPantheonVersionByPathInManifest,
+    getActivePantheonIds,
+    getPantheonVersionsForActivities,
+    isPantheonVersionSunset as isPantheonVersionSunsetInManifest
+} from "~/lib/manifest/pantheon"
 import type {
     ImageContentData,
     RaidHubActivityDefinition,
@@ -13,18 +19,28 @@ import type {
 type ManifestContextData = RaidHubManifestResponse & {
     listedVerions: readonly number[]
     activeRaids: readonly number[]
+    activePantheonIds: readonly number[]
     pantheonVersions: readonly number[]
+    activePantheonVersions: readonly number[]
+    pantheonBossVersions: readonly number[]
+    activePantheonBossVersions: readonly number[]
+    gauntletVersions: readonly number[]
+    activeGauntletVersions: readonly number[]
     elevatedDifficulties: readonly number[]
     milestoneHashes: Map<number, RaidHubActivityDefinition>
     getVersionString(versionId: number): string
     getActivityString(activityId: number): string
     getUrlPathForActivity(activityId: number): string | null
     getUrlPathForVersion(versionId: number): string | null
+    getActivePantheonActivityId(): number | null
+    isGauntletVersion(versionId: number): boolean
+    isPantheonVersionSunset(versionId: number): boolean
     getDefinitionFromHash(hash: string | number): {
         activity: RaidHubActivityDefinition
         version: RaidHubVersionDefinition
     } | null
     getVersionsForActivity(activityId: number): readonly RaidHubVersionDefinition[]
+    findPantheonVersionByPath(versionPath: string): RaidHubVersionDefinition | null
     getActivityDefinition(activityId: number): RaidHubActivityDefinition | null
     isChallengeMode(versionId: number): boolean
     getImageVariantsForActivity(activityId: number | string): readonly ImageContentData[]
@@ -44,13 +60,30 @@ export function RaidHubManifestManager(props: {
     })
 
     const value = useMemo((): ManifestContextData => {
+        const activePantheonIds = getActivePantheonIds(data)
+        const pantheonVersions = getPantheonVersionsForActivities(data, data.pantheonIds)
+        const activePantheonVersions = getPantheonVersionsForActivities(data, activePantheonIds)
+        const gauntletVersions = data.gauntletVersionIds ?? []
+        const gauntletVersionSet = new Set(gauntletVersions)
+        const pantheonBossVersions = pantheonVersions.filter(id => !gauntletVersionSet.has(id))
+        const activeGauntletVersions = gauntletVersions.filter(
+            id => !isPantheonVersionSunsetInManifest(data, id)
+        )
+        const activePantheonBossVersions = activePantheonVersions.filter(
+            id => !gauntletVersionSet.has(id)
+        )
+
         return {
             ...data,
             listedVerions: Object.keys(data.versionDefinitions).map(Number),
             activeRaids: data.listedRaidIds.filter(id => !data.sunsetRaidIds.includes(id)),
-            pantheonVersions: Array.from(
-                new Set(data.pantheonIds.map(id => data.versionsForActivity[id]).flat())
-            ),
+            activePantheonIds,
+            pantheonVersions,
+            activePantheonVersions,
+            pantheonBossVersions,
+            activePantheonBossVersions,
+            gauntletVersions,
+            activeGauntletVersions,
             elevatedDifficulties: [3, 4],
             milestoneHashes: new Map(
                 Object.entries(data.activityDefinitions)
@@ -69,6 +102,15 @@ export function RaidHubManifestManager(props: {
             getUrlPathForVersion(activityId) {
                 return data.versionDefinitions[activityId]?.path ?? null
             },
+            getActivePantheonActivityId() {
+                return activePantheonIds[0] ?? null
+            },
+            isGauntletVersion(versionId) {
+                return gauntletVersionSet.has(versionId)
+            },
+            isPantheonVersionSunset(versionId) {
+                return isPantheonVersionSunsetInManifest(data, versionId)
+            },
             getDefinitionFromHash(hash) {
                 const obj = data.hashes[hash]
                 if (!obj) return null
@@ -82,6 +124,9 @@ export function RaidHubManifestManager(props: {
                 return (data.versionsForActivity[activityId] ?? []).map(
                     v => data.versionDefinitions[v]
                 )
+            },
+            findPantheonVersionByPath(versionPath) {
+                return findPantheonVersionByPathInManifest(data, versionPath)
             },
             getActivityDefinition(activityId) {
                 return data.activityDefinitions[activityId] ?? null

--- a/src/lib/manifest/pantheon.ts
+++ b/src/lib/manifest/pantheon.ts
@@ -16,7 +16,7 @@ export const findPantheonVersionByPath = (
     }
 
     if (matches.length === 1) {
-        return matches[0]!
+        return matches[0]
     }
 
     return matches.sort((a, b) => {
@@ -26,7 +26,7 @@ export const findPantheonVersionByPath = (
             return activityA.isSunset ? 1 : -1
         }
         return b.associatedActivityId! - a.associatedActivityId!
-    })[0]!
+    })[0]
 }
 
 export const isPantheonVersionSunset = (

--- a/src/lib/manifest/pantheon.ts
+++ b/src/lib/manifest/pantheon.ts
@@ -47,5 +47,4 @@ export const getActivePantheonIds = (manifest: RaidHubManifestResponse) =>
 export const getPantheonVersionsForActivities = (
     manifest: RaidHubManifestResponse,
     activityIds: readonly number[]
-) =>
-    Array.from(new Set(activityIds.flatMap(id => manifest.versionsForActivity[id] ?? [])))
+) => Array.from(new Set(activityIds.flatMap(id => manifest.versionsForActivity[id] ?? [])))

--- a/src/lib/manifest/pantheon.ts
+++ b/src/lib/manifest/pantheon.ts
@@ -1,0 +1,51 @@
+import type { RaidHubManifestResponse, RaidHubVersionDefinition } from "~/services/raidhub/types"
+
+export const findPantheonVersionByPath = (
+    manifest: RaidHubManifestResponse,
+    versionPath: string
+): RaidHubVersionDefinition | null => {
+    const matches = Object.values(manifest.versionDefinitions).filter(
+        version =>
+            version.associatedActivityId !== null &&
+            manifest.pantheonIds.includes(version.associatedActivityId) &&
+            version.path === versionPath
+    )
+
+    if (matches.length === 0) {
+        return null
+    }
+
+    if (matches.length === 1) {
+        return matches[0]!
+    }
+
+    return matches.sort((a, b) => {
+        const activityA = manifest.activityDefinitions[a.associatedActivityId!]
+        const activityB = manifest.activityDefinitions[b.associatedActivityId!]
+        if (+activityA.isSunset ^ +activityB.isSunset) {
+            return activityA.isSunset ? 1 : -1
+        }
+        return b.associatedActivityId! - a.associatedActivityId!
+    })[0]!
+}
+
+export const isPantheonVersionSunset = (
+    manifest: RaidHubManifestResponse,
+    versionId: number
+): boolean => {
+    const version = manifest.versionDefinitions[versionId]
+    if (!version?.associatedActivityId) {
+        return false
+    }
+
+    return manifest.activityDefinitions[version.associatedActivityId]?.isSunset ?? false
+}
+
+export const getActivePantheonIds = (manifest: RaidHubManifestResponse) =>
+    manifest.pantheonIds.filter(id => !manifest.activityDefinitions[id]?.isSunset)
+
+export const getPantheonVersionsForActivities = (
+    manifest: RaidHubManifestResponse,
+    activityIds: readonly number[]
+) =>
+    Array.from(new Set(activityIds.flatMap(id => manifest.versionsForActivity[id] ?? [])))

--- a/src/services/raidhub/openapi.d.ts
+++ b/src/services/raidhub/openapi.d.ts
@@ -107,6 +107,20 @@ export interface paths {
             };
           };
         };
+        /** @description ServiceUnavailableError */
+        503: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "ServiceUnavailableError";
+              readonly error: components["schemas"]["ServiceUnavailableError"];
+            };
+          };
+        };
       };
     };
   };
@@ -1104,6 +1118,14 @@ export interface paths {
               /** @enum {boolean} */
               readonly success: false;
               /** @enum {string} */
+              readonly code: "InvalidActivityVersionComboError";
+              readonly error: components["schemas"]["InvalidActivityVersionComboError"];
+            } | {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
               readonly code: "QueryValidationError";
               readonly error: components["schemas"]["QueryValidationError"];
             };
@@ -1134,14 +1156,6 @@ export interface paths {
               /** @enum {string} */
               readonly code: "PlayerNotOnLeaderboardError";
               readonly error: components["schemas"]["PlayerNotOnLeaderboardError"];
-            } | {
-              /** Format: date-time */
-              readonly minted: string;
-              /** @enum {boolean} */
-              readonly success: false;
-              /** @enum {string} */
-              readonly code: "InvalidActivityVersionComboError";
-              readonly error: components["schemas"]["InvalidActivityVersionComboError"];
             } | {
               /** Format: date-time */
               readonly minted: string;
@@ -1780,18 +1794,15 @@ export interface paths {
         /** @description Not found */
         404: {
           content: {
-            readonly "application/json": ({
+            readonly "application/json": {
               /** Format: date-time */
               readonly minted: string;
               /** @enum {boolean} */
               readonly success: false;
               /** @enum {string} */
               readonly code: "InstanceNotFoundError";
-              readonly error: components["schemas"]["InstanceNotFoundError"] & {
-                /** Format: int64 */
-                readonly instanceId?: string;
-              };
-            }) | {
+              readonly error: components["schemas"]["InstanceNotFoundError"];
+            } | {
               /** Format: date-time */
               readonly minted: string;
               /** @enum {boolean} */
@@ -1896,15 +1907,17 @@ export interface paths {
         /** @description Not found */
         404: {
           content: {
-            readonly "application/json": {
+            readonly "application/json": ({
               /** Format: date-time */
               readonly minted: string;
               /** @enum {boolean} */
               readonly success: false;
               /** @enum {string} */
               readonly code: "InstanceNotFoundError";
-              readonly error: components["schemas"]["InstanceNotFoundError"];
-            } | {
+              readonly error: components["schemas"]["InstanceNotFoundError"] & {
+                readonly instanceId?: string;
+              };
+            }) | {
               /** Format: date-time */
               readonly minted: string;
               /** @enum {boolean} */
@@ -1994,18 +2007,15 @@ export interface paths {
         /** @description Not found */
         404: {
           content: {
-            readonly "application/json": ({
+            readonly "application/json": {
               /** Format: date-time */
               readonly minted: string;
               /** @enum {boolean} */
               readonly success: false;
               /** @enum {string} */
               readonly code: "PlayerNotFoundError";
-              readonly error: components["schemas"]["PlayerNotFoundError"] & {
-                /** Format: int64 */
-                readonly membershipId?: string;
-              };
-            }) | {
+              readonly error: components["schemas"]["PlayerNotFoundError"];
+            } | {
               /** Format: date-time */
               readonly minted: string;
               /** @enum {boolean} */
@@ -2213,7 +2223,7 @@ export type webhooks = Record<string, never>;
 export interface components {
   schemas: {
     /** @enum {string} */
-    readonly ErrorCode: "ApiKeyError" | "PathValidationError" | "QueryValidationError" | "BodyValidationError" | "PlayerNotFoundError" | "PlayerPrivateProfileError" | "PlayerProtectedResourceError" | "InstanceNotFoundError" | "PGCRNotFoundError" | "PlayerNotOnLeaderboardError" | "PlayerNotInInstance" | "RaidNotFoundError" | "PantheonVersionNotFoundError" | "InvalidActivityVersionComboError" | "ClanNotFoundError" | "AdminQuerySyntaxError" | "InsufficientPermissionsError" | "InvalidClientSecretError" | "InternalServerError" | "BungieServiceOffline";
+    readonly ErrorCode: "ApiKeyError" | "PathValidationError" | "QueryValidationError" | "BodyValidationError" | "PlayerNotFoundError" | "PlayerPrivateProfileError" | "PlayerProtectedResourceError" | "InstanceNotFoundError" | "PGCRNotFoundError" | "PlayerNotOnLeaderboardError" | "PlayerNotInInstance" | "RaidNotFoundError" | "PantheonVersionNotFoundError" | "InvalidActivityVersionComboError" | "ClanNotFoundError" | "AdminQuerySyntaxError" | "InsufficientPermissionsError" | "InvalidClientSecretError" | "InternalServerError" | "ServiceUnavailableError" | "BungieServiceOffline";
     readonly RaidHubResponse: OneOf<[{
       /** Format: date-time */
       readonly minted: string;
@@ -2337,7 +2347,7 @@ export interface components {
       /** Format: int64 */
       readonly membershipId: string;
       /** @description The platform on which the player created their account. */
-      readonly membershipType: components["schemas"]["DestinyMembershipType"] | null;
+      readonly membershipType: components["schemas"]["DestinyMembershipType"];
       readonly iconPath: string | null;
       /** @description The platform-specific display name of the player. No longer shown in-game. */
       readonly displayName: string | null;
@@ -2529,10 +2539,10 @@ export interface components {
     };
     readonly ClanStats: {
       readonly aggregateStats: components["schemas"]["ClanAggregateStats"];
-      readonly members: readonly ({
-          readonly playerInfo: components["schemas"]["PlayerInfo"] | null;
+      readonly members: readonly {
+          readonly playerInfo: components["schemas"]["PlayerInfo"];
           readonly stats: components["schemas"]["ClanMemberStats"];
-        })[];
+        }[];
     };
     readonly InstanceMetadata: {
       readonly activityName: string;
@@ -2624,22 +2634,7 @@ export interface components {
        */
       readonly page?: number;
     };
-    /**
-     * @description The definition of an activity in the RaidHub database.
-     * @example {
-     *   "id": 9,
-     *   "name": "Vault of Glass",
-     *   "path": "vaultofglass",
-     *   "isSunset": false,
-     *   "isRaid": true,
-     *   "releaseDate": "2021-05-22T00:00:00.000Z",
-     *   "dayOneEnd": "2021-05-23T00:00:00.000Z",
-     *   "contestEnd": "2021-05-23T00:00:00.000Z",
-     *   "weekOneEnd": "2021-05-25T00:00:00.000Z",
-     *   "milestoneHash": 1888320892,
-     *   "splashSlug": "vog"
-     * }
-     */
+    /** @description The definition of an activity in the RaidHub database. */
     readonly ActivityDefinition: {
       readonly id: number;
       readonly name: string;
@@ -2675,7 +2670,7 @@ export interface components {
      * @example medium
      * @enum {string}
      */
-    readonly ImageSize: "tiny" | "small" | "medium" | "large" | "xlarge";
+    readonly ImageSize: "tiny" | "small" | "medium" | "large" | "xlarge" | "full";
     /**
      * @description A URL to a piece of content hosted on the RaidHub CDN.
      * @example {
@@ -2738,7 +2733,8 @@ export interface components {
               readonly iconPath?: string | null;
               readonly crossSaveOverride: components["schemas"]["DestinyMembershipType"];
               readonly applicableMembershipTypes?: (readonly components["schemas"]["DestinyMembershipType"][]) | null;
-              readonly membershipType?: components["schemas"]["DestinyMembershipType"] | null;
+              readonly membershipType?: components["schemas"]["DestinyMembershipType"];
+              /** Format: int64 */
               readonly membershipId: string;
               readonly displayName?: string | null;
               readonly bungieGlobalDisplayName?: string | null;
@@ -2756,6 +2752,7 @@ export interface components {
             /** Format: uint32 */
             readonly emblemHash: number;
           };
+          /** Format: int64 */
           readonly characterId: string;
           readonly values: {
             [key: string]: {
@@ -2799,7 +2796,7 @@ export interface components {
       readonly freshClears: number;
       readonly clears: number;
       readonly sherpas: number;
-      readonly fastestInstance: components["schemas"]["Instance"] | null;
+      readonly fastestInstance: components["schemas"]["Instance"];
     };
     readonly GlobalStat: {
       readonly value: number;
@@ -2834,7 +2831,7 @@ export interface components {
         };
       };
       readonly worldFirstEntries: {
-        [key: string]: components["schemas"]["WorldFirstEntry"] | null;
+        [key: string]: components["schemas"]["WorldFirstEntry"];
       };
     };
     readonly Teammate: {
@@ -2864,7 +2861,7 @@ export interface components {
       readonly incomingRate: number;
       readonly resolveRate: number;
       readonly backlog: number;
-      readonly latestResolvedInstance: components["schemas"]["LatestResolvedInstance"] | null;
+      readonly latestResolvedInstance: components["schemas"]["LatestResolvedInstance"];
       /** Format: date-time */
       readonly estimatedBacklogEmptied: string | null;
     };
@@ -2900,6 +2897,8 @@ export interface components {
       readonly resprisedChallengeVersionIds: readonly number[];
       /** @description The list of activityId for Pantheon */
       readonly pantheonIds: readonly number[];
+      /** @description The list of versionId for Pantheon gauntlet modes (full boss lineup) */
+      readonly gauntletVersionIds: readonly number[];
       /** @description The set of versionId for each activityId */
       readonly versionsForActivity: {
         [key: string]: readonly number[];
@@ -2920,6 +2919,10 @@ export interface components {
       readonly AtlasPGCR: components["schemas"]["AtlasStatus"];
       readonly FloodgatesPGCR: components["schemas"]["FloodgatesStatus"];
     };
+    readonly ServiceUnavailableError: {
+      readonly serviceName: string;
+      readonly message: string;
+    };
     readonly PlayerSearchResponse: {
       readonly params: {
         readonly count: number;
@@ -2928,15 +2931,18 @@ export interface components {
       readonly results: readonly components["schemas"]["PlayerInfo"][];
     };
     readonly PlayerHistoryResponse: {
+      /** Format: int64 */
       readonly membershipId: string;
       /** Format: date-time */
       readonly nextCursor: string | null;
       readonly activities: readonly components["schemas"]["InstanceForPlayer"][];
     };
     readonly PlayerNotFoundError: {
+      /** Format: int64 */
       readonly membershipId: string;
     };
     readonly PlayerPrivateProfileError: {
+      /** Format: int64 */
       readonly membershipId: string;
     };
     /**
@@ -2956,7 +2962,7 @@ export interface components {
       /** Format: int64 */
       readonly membershipId: string;
       /** @description The platform on which the player created their account. */
-      readonly membershipType: components["schemas"]["DestinyMembershipType"] | null;
+      readonly membershipType: components["schemas"]["DestinyMembershipType"];
       readonly iconPath: string | null;
       /** @description The platform-specific display name of the player. No longer shown in-game. */
       readonly displayName: string | null;
@@ -2977,13 +2983,14 @@ export interface components {
         };
       };
       readonly worldFirstEntries: {
-        [key: string]: components["schemas"]["WorldFirstEntry"] | null;
+        [key: string]: components["schemas"]["WorldFirstEntry"];
       };
     };
     readonly PlayerTeammatesResponse: readonly components["schemas"]["Teammate"][];
     readonly PlayerInstancesResponse: readonly components["schemas"]["InstanceWithPlayers"][];
     readonly PlayerProtectedResourceError: {
       readonly message: string;
+      /** Format: int64 */
       readonly membershipId: string;
     };
     readonly InstanceResponse: components["schemas"]["Instance"] & ({
@@ -2992,6 +2999,7 @@ export interface components {
       readonly players: readonly components["schemas"]["InstancePlayerExtended"][];
     });
     readonly InstanceNotFoundError: {
+      /** Format: int64 */
       readonly instanceId: string;
     };
     readonly LeaderboardIndividualGlobalResponse: OneOf<[{
@@ -3012,6 +3020,7 @@ export interface components {
       readonly entries: readonly components["schemas"]["IndividualLeaderboardEntry"][];
     }]>;
     readonly PlayerNotOnLeaderboardError: {
+      /** Format: int64 */
       readonly membershipId: string;
     };
     readonly LeaderboardIndividualRaidResponse: OneOf<[{
@@ -3117,7 +3126,8 @@ export interface components {
               readonly iconPath?: string | null;
               readonly crossSaveOverride: components["schemas"]["DestinyMembershipType"];
               readonly applicableMembershipTypes?: (readonly components["schemas"]["DestinyMembershipType"][]) | null;
-              readonly membershipType?: components["schemas"]["DestinyMembershipType"] | null;
+              readonly membershipType?: components["schemas"]["DestinyMembershipType"];
+              /** Format: int64 */
               readonly membershipId: string;
               readonly displayName?: string | null;
               readonly bungieGlobalDisplayName?: string | null;
@@ -3135,6 +3145,7 @@ export interface components {
             /** Format: uint32 */
             readonly emblemHash: number;
           };
+          /** Format: int64 */
           readonly characterId: string;
           readonly values: {
             [key: string]: {
@@ -3168,16 +3179,18 @@ export interface components {
         })[];
     };
     readonly PGCRNotFoundError: {
+      /** Format: int64 */
       readonly instanceId: string;
     };
     readonly ClanResponse: {
       readonly aggregateStats: components["schemas"]["ClanAggregateStats"];
-      readonly members: readonly ({
-          readonly playerInfo: components["schemas"]["PlayerInfo"] | null;
+      readonly members: readonly {
+          readonly playerInfo: components["schemas"]["PlayerInfo"];
           readonly stats: components["schemas"]["ClanMemberStats"];
-        })[];
+        }[];
     };
     readonly ClanNotFoundError: {
+      /** Format: int64 */
       readonly groupId: string;
     };
     readonly BungieServiceOffline: {
@@ -3219,7 +3232,7 @@ export interface components {
     };
     readonly AdminReportingStandingResponse: {
       readonly instanceDetails: components["schemas"]["InstanceBasic"];
-      readonly blacklist: components["schemas"]["InstanceBlacklist"] | null;
+      readonly blacklist: components["schemas"]["InstanceBlacklist"];
       readonly flags: readonly components["schemas"]["InstanceFlag"][];
       readonly players: readonly components["schemas"]["InstancePlayerStanding"][];
     };
@@ -3227,6 +3240,7 @@ export interface components {
       readonly blacklisted: boolean;
     };
     readonly PlayerNotInInstance: {
+      /** Format: int64 */
       readonly instanceId: string;
       readonly players: readonly string[];
     };

--- a/src/services/raidhub/openapi.d.ts
+++ b/src/services/raidhub/openapi.d.ts
@@ -2897,6 +2897,8 @@ export interface components {
       readonly resprisedChallengeVersionIds: readonly number[];
       /** @description The list of activityId for Pantheon */
       readonly pantheonIds: readonly number[];
+      /** @description The list of versionId for Pantheon gauntlet modes (full boss lineup) */
+      readonly gauntletVersionIds: readonly number[];
       /** @description The set of versionId for each activityId */
       readonly versionsForActivity: {
         [key: string]: readonly number[];

--- a/src/services/raidhub/openapi.d.ts
+++ b/src/services/raidhub/openapi.d.ts
@@ -2897,8 +2897,6 @@ export interface components {
       readonly resprisedChallengeVersionIds: readonly number[];
       /** @description The list of activityId for Pantheon */
       readonly pantheonIds: readonly number[];
-      /** @description The list of versionId for Pantheon gauntlet modes (full boss lineup) */
-      readonly gauntletVersionIds: readonly number[];
       /** @description The set of versionId for each activityId */
       readonly versionsForActivity: {
         [key: string]: readonly number[];


### PR DESCRIPTION
## Summary

Pantheon 2.0 website: manifest-driven modes, sunset UX, and gauntlet UI from API manifest.

- **Activity 101** (`thepantheon`, sunset): historical EP boss modes (128–131) shown with sunset styling
- **Activity 102** (`pantheon`, active): Calus (132) and Morgeth (133) from manifest
- **Gauntlet**: UI driven by manifest `gauntletVersionIds` (no hardcoded placeholder v134 — empty until DB has gauntlet versions)
- `src/lib/manifest/pantheon.ts` helpers aligned with API manifest
- Home buckets, profile Pantheon layout, manifest manager, and pantheon leaderboard pages updated for multi-activity pantheon

## Deploy order

1. **Services** [#46](https://github.com/Raid-Hub/Services/pull/46) + production data (`docs/pantheon-2.0-deploy-plan.md`)
2. **API** [#132](https://github.com/Raid-Hub/API/pull/132)
3. **Website** (this PR)

## Test plan

- [ ] `bunx tsc --noEmit` and `bun run format:check`
- [ ] Home page Pantheon bucket shows active boss modes (Calus, Morgeth) and gauntlet section when `gauntletVersionIds` is non-empty
- [ ] Profile with Pantheon history: sunset UX for activity 101 modes vs active activity 102 layout
- [ ] Individual pantheon leaderboards for each version/category
- [ ] Manifest overlay loads without errors