### PR TITLE
Pantheon 2.0: flat pantheon UI and Adventure badge

### DIFF
--- a/src/components/CloudflareImage.tsx
+++ b/src/components/CloudflareImage.tsx
@@ -35,7 +35,7 @@ const cloudflareVariants: {
     }
 ]
 
-export const FallbackSplash = "https://cdn.raidhub.io/content/splash/pantheon/medium.png"
+export const FallbackSplash = "https://cdn.raidhub.io/content/splash/pantheon/large.png"
 
 const CloudflareStaticImages = {
     raidhubCitySplash: {
@@ -121,9 +121,10 @@ export const CloudflareIcon = ({
 
 export const CloudflareActivitySplash = ({
     activityId,
+    versionId,
     alt,
     ...props
-}: { activityId: number } & StrippedImageProps) => {
+}: { activityId: number; versionId?: number } & StrippedImageProps) => {
     const { getImageVariantsForActivity, getActivityDefinition, getVersionString } =
         useRaidHubManifest()
 
@@ -156,7 +157,7 @@ export const CloudflareActivitySplash = ({
         alt ??
         (activityDefinition?.isRaid
             ? activityDefinition.name
-            : (getVersionString(activityId) + getActivityDefinition(activityId)?.name ?? ""))
+            : getVersionString(versionId ?? activityId))
 
     return <Image loader={loader} {...props} src="placeholder" alt={altText} />
 }

--- a/src/components/__deprecated__/profile/raids/RaidCard.tsx
+++ b/src/components/__deprecated__/profile/raids/RaidCard.tsx
@@ -30,11 +30,12 @@ export default function RaidCard({
     leaderboardEntry: RaidHubWorldFirstEntry | null
     isExpanded?: boolean
 }) {
-    const { activities, isLoadingActivities, raidId } = useRaidCardContext()
+    const { activities, isLoadingActivities, raidId, versionId } = useRaidCardContext()
     const { getVersionString, resprisedRaidIds, isChallengeMode, getActivityDefinition } =
         useRaidHubManifest()
     const { locale } = useLocale()
 
+    const displayVersionId = versionId ?? raidId
     const activityDefinition = getActivityDefinition(raidId)
 
     const isReprisedRaid = resprisedRaidIds.includes(raidId)
@@ -165,6 +166,7 @@ export default function RaidCard({
                     width={960}
                     height={540}
                     activityId={raidId}
+                    versionId={versionId}
                 />
                 <div className={styles["card-top"]}>
                     {firstContestClear && (
@@ -200,7 +202,7 @@ export default function RaidCard({
                     <span className={styles["card-title"]}>
                         {activityDefinition?.isRaid
                             ? activityDefinition.name
-                            : getVersionString(raidId)}
+                            : getVersionString(displayVersionId)}
                     </span>
                 </div>
             </div>

--- a/src/components/home/HomeBuckets.tsx
+++ b/src/components/home/HomeBuckets.tsx
@@ -308,17 +308,11 @@ function PantheonModeLinks({
 }
 
 function PantheonLinks() {
-    const { activePantheonBossVersions, activeGauntletVersions } = useRaidHubManifest()
+    const { activePantheonVersions } = useRaidHubManifest()
 
     return (
         <div>
-            <PantheonModeLinks versions={activePantheonBossVersions} keyPrefix="boss" />
-            {activeGauntletVersions.length > 0 && (
-                <div className="mt-4">
-                    <h3 className="mb-2 text-lg font-bold">Gauntlet</h3>
-                    <PantheonModeLinks versions={activeGauntletVersions} keyPrefix="gauntlet" />
-                </div>
-            )}
+            <PantheonModeLinks versions={activePantheonVersions} keyPrefix="pantheon" />
         </div>
     )
 }

--- a/src/components/pgcr/pgcr-header.tsx
+++ b/src/components/pgcr/pgcr-header.tsx
@@ -99,6 +99,13 @@ export const PGCRHeader = ({ data }: PGCRHeaderProps) => {
                             {data.isContest ? "Contest" : data.metadata.versionName}
                         </Badge>
                     )}
+                    {data.difficultyTier === "adventure" && (
+                        <Badge
+                            variant="secondary"
+                            className="bg-amber-600/90 text-sm text-amber-50">
+                            Adventure
+                        </Badge>
+                    )}
 
                     {/* Tags & Feats */}
                     <PGCRTags />

--- a/src/components/profile/raids/PantheonLayout.tsx
+++ b/src/components/profile/raids/PantheonLayout.tsx
@@ -1,5 +1,5 @@
 import { Collection } from "@discordjs/collection"
-import { useMemo } from "react"
+import { useCallback, useMemo } from "react"
 import { Grid } from "~/components/__deprecated__/layout/Grid"
 import RaidCard from "~/components/__deprecated__/profile/raids/RaidCard"
 import { useRaidHubManifest } from "~/components/providers/RaidHubManifestManager"
@@ -10,12 +10,14 @@ const PantheonModeGrid = ({
     modes,
     instancesByMode,
     isLoading,
-    isExpanded
+    isExpanded,
+    getActivityIdForVersion
 }: {
     modes: readonly number[]
     instancesByMode: Collection<number, Collection<string, RaidHubInstanceForPlayer>> | null
     isLoading: boolean
     isExpanded: boolean
+    getActivityIdForVersion: (versionId: number) => number
 }) => (
     <Grid as="section" $minCardWidth={325} $minCardWidthMobile={300} $fullWidth $relative>
         {modes
@@ -25,7 +27,8 @@ const PantheonModeGrid = ({
                     key={mode}
                     activities={instancesByMode?.get(mode)}
                     isLoadingActivities={isLoading}
-                    raidId={mode}>
+                    raidId={getActivityIdForVersion(mode)}
+                    versionId={mode}>
                     <RaidCard leaderboardEntry={null} isExpanded={isExpanded} />
                 </RaidCardContext>
             ))}
@@ -41,7 +44,14 @@ export const PantheonLayout = ({
     isExpanded: boolean
     isLoading: boolean
 }) => {
-    const { activePantheonVersions, pantheonSunsetVersions } = useRaidHubManifest()
+    const { activePantheonVersions, pantheonSunsetVersions, versionDefinitions, activePantheonIds } =
+        useRaidHubManifest()
+
+    const getActivityIdForVersion = useCallback(
+        (versionId: number) =>
+            versionDefinitions[versionId]?.associatedActivityId ?? activePantheonIds[0] ?? 102,
+        [activePantheonIds, versionDefinitions]
+    )
 
     const instancesByMode = useMemo(() => {
         if (isLoading) return null
@@ -63,6 +73,7 @@ export const PantheonLayout = ({
                 instancesByMode={instancesByMode}
                 isLoading={isLoading}
                 isExpanded={isExpanded}
+                getActivityIdForVersion={getActivityIdForVersion}
             />
             {pantheonSunsetVersions.length > 0 && (
                 <div>
@@ -74,6 +85,7 @@ export const PantheonLayout = ({
                         instancesByMode={instancesByMode}
                         isLoading={isLoading}
                         isExpanded={isExpanded}
+                        getActivityIdForVersion={getActivityIdForVersion}
                     />
                 </div>
             )}

--- a/src/components/profile/raids/PantheonLayout.tsx
+++ b/src/components/profile/raids/PantheonLayout.tsx
@@ -41,18 +41,7 @@ export const PantheonLayout = ({
     isExpanded: boolean
     isLoading: boolean
 }) => {
-    const {
-        activeGauntletVersions,
-        activePantheonBossVersions,
-        gauntletVersions,
-        pantheonBossVersions,
-        isPantheonVersionSunset
-    } = useRaidHubManifest()
-
-    const activeModes = [...activeGauntletVersions, ...activePantheonBossVersions]
-    const historicalModes = [...gauntletVersions, ...pantheonBossVersions].filter(id =>
-        isPantheonVersionSunset(id)
-    )
+    const { activePantheonVersions, pantheonSunsetVersions } = useRaidHubManifest()
 
     const instancesByMode = useMemo(() => {
         if (isLoading) return null
@@ -70,18 +59,18 @@ export const PantheonLayout = ({
     return (
         <div className="flex w-full flex-col gap-6">
             <PantheonModeGrid
-                modes={activeModes}
+                modes={activePantheonVersions}
                 instancesByMode={instancesByMode}
                 isLoading={isLoading}
                 isExpanded={isExpanded}
             />
-            {historicalModes.length > 0 && (
+            {pantheonSunsetVersions.length > 0 && (
                 <div>
                     <h3 className="text-secondary mb-3 text-sm font-semibold tracking-wide uppercase">
                         Historical Modes
                     </h3>
                     <PantheonModeGrid
-                        modes={historicalModes}
+                        modes={pantheonSunsetVersions}
                         instancesByMode={instancesByMode}
                         isLoading={isLoading}
                         isExpanded={isExpanded}

--- a/src/components/profile/raids/PantheonLayout.tsx
+++ b/src/components/profile/raids/PantheonLayout.tsx
@@ -44,8 +44,12 @@ export const PantheonLayout = ({
     isExpanded: boolean
     isLoading: boolean
 }) => {
-    const { activePantheonVersions, pantheonSunsetVersions, versionDefinitions, activePantheonIds } =
-        useRaidHubManifest()
+    const {
+        activePantheonVersions,
+        pantheonSunsetVersions,
+        versionDefinitions,
+        activePantheonIds
+    } = useRaidHubManifest()
 
     const getActivityIdForVersion = useCallback(
         (versionId: number) =>

--- a/src/components/profile/raids/RaidCardContext.tsx
+++ b/src/components/profile/raids/RaidCardContext.tsx
@@ -7,10 +7,11 @@ import { type RaidHubInstanceForPlayer } from "~/services/raidhub/types"
 const RaidContext = createContext<
     | {
           raidId: number
+          versionId?: number
           isLoadingActivities: false
           activities: Collection<string, RaidHubInstanceForPlayer>
       }
-    | { raidId: number; isLoadingActivities: true; activities: null }
+    | { raidId: number; versionId?: number; isLoadingActivities: true; activities: null }
     | null
 >(null)
 
@@ -24,12 +25,15 @@ export const RaidCardContext = ({
     children,
     activities = new Collection(),
     isLoadingActivities,
-    raidId
+    raidId,
+    versionId
 }: {
     children: ReactNode
     activities: Collection<string, RaidHubInstanceForPlayer> | undefined
     isLoadingActivities: boolean
     raidId: number
+    /** Pantheon cards pass the encounter version separately from the parent activity id. */
+    versionId?: number
 }) => {
     const memoizedSortedActivities = useMemo(
         () =>
@@ -43,6 +47,7 @@ export const RaidCardContext = ({
         <RaidContext.Provider
             value={{
                 raidId,
+                versionId,
                 ...(isLoadingActivities
                     ? { isLoadingActivities: true, activities: null }
                     : {

--- a/src/components/providers/RaidHubManifestManager.tsx
+++ b/src/components/providers/RaidHubManifestManager.tsx
@@ -56,8 +56,8 @@ export function RaidHubManifestManager(props: {
 
     const value = useMemo((): ManifestContextData => {
         const activePantheonIds = getActivePantheonIds(data)
-        const activePantheonVersions = data.pantheonVersionIds
-        const pantheonSunsetVersions = data.pantheonSunsetVersionIds
+        const activePantheonVersions = data.pantheonVersionIds ?? []
+        const pantheonSunsetVersions = data.pantheonSunsetVersionIds ?? []
         const pantheonVersions = [...activePantheonVersions, ...pantheonSunsetVersions]
 
         return {

--- a/src/components/providers/RaidHubManifestManager.tsx
+++ b/src/components/providers/RaidHubManifestManager.tsx
@@ -5,7 +5,6 @@ import { createContext, useContext, useMemo, type ReactNode } from "react"
 import {
     findPantheonVersionByPath as findPantheonVersionByPathInManifest,
     getActivePantheonIds,
-    getPantheonVersionsForActivities,
     isPantheonVersionSunset as isPantheonVersionSunsetInManifest
 } from "~/lib/manifest/pantheon"
 import { getRaidHubApi } from "~/services/raidhub/common"
@@ -22,10 +21,7 @@ type ManifestContextData = RaidHubManifestResponse & {
     activePantheonIds: readonly number[]
     pantheonVersions: readonly number[]
     activePantheonVersions: readonly number[]
-    pantheonBossVersions: readonly number[]
-    activePantheonBossVersions: readonly number[]
-    gauntletVersions: readonly number[]
-    activeGauntletVersions: readonly number[]
+    pantheonSunsetVersions: readonly number[]
     elevatedDifficulties: readonly number[]
     milestoneHashes: Map<number, RaidHubActivityDefinition>
     getVersionString(versionId: number): string
@@ -33,7 +29,6 @@ type ManifestContextData = RaidHubManifestResponse & {
     getUrlPathForActivity(activityId: number): string | null
     getUrlPathForVersion(versionId: number): string | null
     getActivePantheonActivityId(): number | null
-    isGauntletVersion(versionId: number): boolean
     isPantheonVersionSunset(versionId: number): boolean
     getDefinitionFromHash(hash: string | number): {
         activity: RaidHubActivityDefinition
@@ -61,17 +56,9 @@ export function RaidHubManifestManager(props: {
 
     const value = useMemo((): ManifestContextData => {
         const activePantheonIds = getActivePantheonIds(data)
-        const pantheonVersions = getPantheonVersionsForActivities(data, data.pantheonIds)
-        const activePantheonVersions = getPantheonVersionsForActivities(data, activePantheonIds)
-        const gauntletVersions = data.gauntletVersionIds ?? []
-        const gauntletVersionSet = new Set(gauntletVersions)
-        const pantheonBossVersions = pantheonVersions.filter(id => !gauntletVersionSet.has(id))
-        const activeGauntletVersions = gauntletVersions.filter(
-            id => !isPantheonVersionSunsetInManifest(data, id)
-        )
-        const activePantheonBossVersions = activePantheonVersions.filter(
-            id => !gauntletVersionSet.has(id)
-        )
+        const activePantheonVersions = data.pantheonVersionIds
+        const pantheonSunsetVersions = data.pantheonSunsetVersionIds
+        const pantheonVersions = [...activePantheonVersions, ...pantheonSunsetVersions]
 
         return {
             ...data,
@@ -80,10 +67,7 @@ export function RaidHubManifestManager(props: {
             activePantheonIds,
             pantheonVersions,
             activePantheonVersions,
-            pantheonBossVersions,
-            activePantheonBossVersions,
-            gauntletVersions,
-            activeGauntletVersions,
+            pantheonSunsetVersions,
             elevatedDifficulties: [3, 4],
             milestoneHashes: new Map(
                 Object.entries(data.activityDefinitions)
@@ -104,9 +88,6 @@ export function RaidHubManifestManager(props: {
             },
             getActivePantheonActivityId() {
                 return activePantheonIds[0] ?? null
-            },
-            isGauntletVersion(versionId) {
-                return gauntletVersionSet.has(versionId)
             },
             isPantheonVersionSunset(versionId) {
                 return isPantheonVersionSunsetInManifest(data, versionId)

--- a/src/services/raidhub/openapi.d.ts
+++ b/src/services/raidhub/openapi.d.ts
@@ -2741,6 +2741,11 @@ export interface components {
     readonly QueryValidationError: {
       readonly issues: readonly components["schemas"]["ZodIssue"][];
     };
+    /**
+     * @description MotT difficulty tier derived from PGCR skull hashes. Adventure uses fixed skulls; Custom has selected feats; Standard is Custom with no feats.
+     * @enum {string}
+     */
+    readonly DifficultyTier: "adventure" | "standard" | "custom";
     /** @enum {integer} */
     readonly DestinyMembershipType: 0 | 1 | 2 | 3 | 4 | 5 | 6 | -1;
     readonly Instance: {
@@ -2753,6 +2758,7 @@ export interface components {
       readonly fresh: boolean | null;
       readonly playerCount: number;
       readonly skullHashes: readonly number[];
+      readonly difficultyTier: components["schemas"]["DifficultyTier"];
       readonly score: number;
       /** Format: date-time */
       readonly dateStarted: string;
@@ -2783,6 +2789,7 @@ export interface components {
       readonly fresh: boolean | null;
       readonly playerCount: number;
       readonly skullHashes: readonly number[];
+      readonly difficultyTier: components["schemas"]["DifficultyTier"];
       readonly score: number;
       /** Format: date-time */
       readonly dateStarted: string;

--- a/src/services/raidhub/openapi.d.ts
+++ b/src/services/raidhub/openapi.d.ts
@@ -135,6 +135,7 @@ export interface paths {
       parameters: {
         query: {
           count?: number;
+          offset?: number | null;
           query: string;
           membershipType?: components["schemas"]["DestinyMembershipType"];
           global?: boolean;
@@ -1530,6 +1531,97 @@ export interface paths {
       };
     };
   };
+  "/clan/{groupId}/basic": {
+    /**
+     * /clan/{groupId}/basic
+     * @description Low-cost clan identity (name, tag, avatar path) for bots and UIs. Does not load member rosters.
+     */
+    get: {
+      parameters: {
+        path: {
+          groupId: string;
+        };
+      };
+      responses: {
+        /** @description Success */
+        200: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: true;
+              readonly response: components["schemas"]["ClanBasicResponse"];
+            };
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "ApiKeyError";
+              readonly error: components["schemas"]["ApiKeyError"];
+            };
+          };
+        };
+        /** @description Not found */
+        404: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "ClanNotFoundError";
+              readonly error: components["schemas"]["ClanNotFoundError"];
+            } | {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "PathValidationError";
+              readonly error: components["schemas"]["PathValidationError"];
+            };
+          };
+        };
+        /** @description Internal Server Error */
+        500: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "InternalServerError";
+              readonly error: components["schemas"]["InternalServerError"];
+            };
+          };
+        };
+        /** @description BungieServiceOffline */
+        503: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "BungieServiceOffline";
+              readonly error: components["schemas"]["BungieServiceOffline"];
+            };
+          };
+        };
+      };
+    };
+  };
   "/metrics/weapons/rolling-week": {
     /**
      * /metrics/weapons/rolling-week
@@ -1756,7 +1848,7 @@ export interface paths {
   "/admin/reporting/standing/{instanceId}": {
     /**
      * /admin/reporting/standing/{instanceId}
-     * @description Find a set of instances based on the query parameters. Some parameters will not work together, such as providing a season outside the range of the min/max season. Requires authentication.
+     * @description Get the standing information for a specific instance, including flags, blacklist status, and per-player standing data.
      */
     get: {
       parameters: {
@@ -1788,6 +1880,20 @@ export interface paths {
               /** @enum {string} */
               readonly code: "ApiKeyError";
               readonly error: components["schemas"]["ApiKeyError"];
+            };
+          };
+        };
+        /** @description Forbidden */
+        403: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "InsufficientPermissionsError";
+              readonly error: components["schemas"]["InsufficientPermissionsError"];
             };
           };
         };
@@ -1904,6 +2010,20 @@ export interface paths {
             };
           };
         };
+        /** @description Forbidden */
+        403: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "InsufficientPermissionsError";
+              readonly error: components["schemas"]["InsufficientPermissionsError"];
+            };
+          };
+        };
         /** @description Not found */
         404: {
           content: {
@@ -1948,6 +2068,95 @@ export interface paths {
   "/admin/reporting/player/{membershipId}": {
     /**
      * /admin/reporting/player/{membershipId}
+     * @description Get a player's standing information including recent flags and blacklisted instances. Requires authentication.
+     */
+    get: {
+      parameters: {
+        path: {
+          membershipId: string;
+        };
+      };
+      responses: {
+        /** @description Success */
+        200: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: true;
+              readonly response: components["schemas"]["AdminReportingPlayerResponse"];
+            };
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "ApiKeyError";
+              readonly error: components["schemas"]["ApiKeyError"];
+            };
+          };
+        };
+        /** @description Forbidden */
+        403: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "InsufficientPermissionsError";
+              readonly error: components["schemas"]["InsufficientPermissionsError"];
+            };
+          };
+        };
+        /** @description Not found */
+        404: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "PlayerNotFoundError";
+              readonly error: components["schemas"]["PlayerNotFoundError"];
+            } | {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "PathValidationError";
+              readonly error: components["schemas"]["PathValidationError"];
+            };
+          };
+        };
+        /** @description Internal Server Error */
+        500: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "InternalServerError";
+              readonly error: components["schemas"]["InternalServerError"];
+            };
+          };
+        };
+      };
+    };
+    /**
+     * /admin/reporting/player/{membershipId}
      * @description Update fields on a player. Currently, only the cheat level can be updated.
      */
     patch: {
@@ -1972,7 +2181,7 @@ export interface paths {
               readonly minted: string;
               /** @enum {boolean} */
               readonly success: true;
-              readonly response: components["schemas"]["AdminReportingPlayerResponse"];
+              readonly response: components["schemas"]["AdminReportingPlayerResponse"] & string;
             };
           };
         };
@@ -2001,6 +2210,20 @@ export interface paths {
               /** @enum {string} */
               readonly code: "ApiKeyError";
               readonly error: components["schemas"]["ApiKeyError"];
+            };
+          };
+        };
+        /** @description Forbidden */
+        403: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "InsufficientPermissionsError";
+              readonly error: components["schemas"]["InsufficientPermissionsError"];
             };
           };
         };
@@ -2216,6 +2439,258 @@ export interface paths {
       };
     };
   };
+  "/subscriptions/discord/webhooks": {
+    /**
+     * /subscriptions/discord/webhooks
+     * @description Get RaidHub subscription webhook status for the current channel (no secrets).
+     */
+    get: {
+      responses: {
+        /** @description Success */
+        200: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: true;
+              readonly response: components["schemas"]["SubscriptionsDiscordWebhooksResponse"];
+            };
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "InvalidDiscordAuthError";
+              readonly error: components["schemas"]["InvalidDiscordAuthError"];
+            } | {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "ApiKeyError";
+              readonly error: components["schemas"]["ApiKeyError"];
+            };
+          };
+        };
+        /** @description InsufficientPermissionsError */
+        403: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "InsufficientPermissionsError";
+              readonly error: components["schemas"]["InsufficientPermissionsError"];
+            };
+          };
+        };
+        /** @description Internal Server Error */
+        500: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "InternalServerError";
+              readonly error: components["schemas"]["InternalServerError"];
+            };
+          };
+        };
+      };
+    };
+    /**
+     * /subscriptions/discord/webhooks
+     * @description Create or update the RaidHub subscription webhook for this channel (idempotent upsert).
+     */
+    put: {
+      readonly requestBody: {
+        readonly content: {
+          readonly "application/json": components["schemas"]["DiscordWebhookBody"];
+        };
+      };
+      responses: {
+        /** @description Success */
+        200: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: true;
+              readonly response: components["schemas"]["SubscriptionsDiscordWebhooksResponse"] & {
+                readonly guildId: string;
+                readonly channelId: string;
+                readonly webhookId: string;
+                /** Format: uri */
+                readonly webhookUrl?: string;
+                readonly created: boolean;
+                readonly activated: boolean;
+                readonly updated: boolean;
+                readonly rules: {
+                  readonly players: {
+                    readonly inserted: number;
+                    readonly updated: number;
+                  };
+                  readonly clans: {
+                    readonly inserted: number;
+                    readonly updated: number;
+                  };
+                };
+              };
+            };
+          };
+        };
+        /** @description Bad request */
+        400: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "BodyValidationError";
+              readonly error: components["schemas"]["BodyValidationError"];
+            };
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "InvalidDiscordAuthError";
+              readonly error: components["schemas"]["InvalidDiscordAuthError"];
+            } | {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "ApiKeyError";
+              readonly error: components["schemas"]["ApiKeyError"];
+            };
+          };
+        };
+        /** @description InsufficientPermissionsError */
+        403: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "InsufficientPermissionsError";
+              readonly error: components["schemas"]["InsufficientPermissionsError"];
+            };
+          };
+        };
+        /** @description Internal Server Error */
+        500: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "InternalServerError";
+              readonly error: components["schemas"]["InternalServerError"];
+            };
+          };
+        };
+      };
+    };
+    /**
+     * /subscriptions/discord/webhooks
+     * @description Delete a Discord subscription webhook registration for the current channel.
+     */
+    delete: {
+      responses: {
+        /** @description Success */
+        200: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: true;
+              readonly response: components["schemas"]["SubscriptionsDiscordWebhooksResponse"] & {
+                readonly deleted: boolean;
+              };
+            };
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "InvalidDiscordAuthError";
+              readonly error: components["schemas"]["InvalidDiscordAuthError"];
+            } | {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "ApiKeyError";
+              readonly error: components["schemas"]["ApiKeyError"];
+            };
+          };
+        };
+        /** @description InsufficientPermissionsError */
+        403: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "InsufficientPermissionsError";
+              readonly error: components["schemas"]["InsufficientPermissionsError"];
+            };
+          };
+        };
+        /** @description Internal Server Error */
+        500: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "InternalServerError";
+              readonly error: components["schemas"]["InternalServerError"];
+            };
+          };
+        };
+      };
+    };
+  };
 }
 
 export type webhooks = Record<string, never>;
@@ -2223,7 +2698,7 @@ export type webhooks = Record<string, never>;
 export interface components {
   schemas: {
     /** @enum {string} */
-    readonly ErrorCode: "ApiKeyError" | "PathValidationError" | "QueryValidationError" | "BodyValidationError" | "PlayerNotFoundError" | "PlayerPrivateProfileError" | "PlayerProtectedResourceError" | "InstanceNotFoundError" | "PGCRNotFoundError" | "PlayerNotOnLeaderboardError" | "PlayerNotInInstance" | "RaidNotFoundError" | "PantheonVersionNotFoundError" | "InvalidActivityVersionComboError" | "ClanNotFoundError" | "AdminQuerySyntaxError" | "InsufficientPermissionsError" | "InvalidClientSecretError" | "InternalServerError" | "ServiceUnavailableError" | "BungieServiceOffline";
+    readonly ErrorCode: "ApiKeyError" | "PathValidationError" | "QueryValidationError" | "BodyValidationError" | "PlayerNotFoundError" | "PlayerPrivateProfileError" | "PlayerProtectedResourceError" | "InstanceNotFoundError" | "PGCRNotFoundError" | "PlayerNotOnLeaderboardError" | "PlayerNotInInstance" | "RaidNotFoundError" | "PantheonVersionNotFoundError" | "InvalidActivityVersionComboError" | "ClanNotFoundError" | "AdminQuerySyntaxError" | "InsufficientPermissionsError" | "InvalidClientSecretError" | "InvalidDiscordAuthError" | "InternalServerError" | "ServiceUnavailableError" | "BungieServiceOffline";
     readonly RaidHubResponse: OneOf<[{
       /** Format: date-time */
       readonly minted: string;
@@ -2291,7 +2766,7 @@ export interface components {
       readonly versionId: number;
       /** @description If the instance was completed before the day one end date */
       readonly isDayOne: boolean;
-      /** @description If the instance was completed before the contest end date */
+      /** @description If this clear was contest mode: when the activity exposes version_id 32 (contest) on activity_version, true only for that version while still before contest_end; otherwise true when completed before contest_end (legacy raids). */
       readonly isContest: boolean;
       /** @description If the instance was completed before the week one end date */
       readonly isWeekOne: boolean;
@@ -2455,6 +2930,8 @@ export interface components {
       readonly instanceId: string;
       /** Format: int64 */
       readonly membershipId: string;
+      /** Format: date-time */
+      readonly instanceDate: string;
     };
     readonly InstancePlayerStanding: {
       readonly playerInfo: components["schemas"]["PlayerInfo"];
@@ -2473,6 +2950,24 @@ export interface components {
           readonly createdAt: string;
         })[];
       readonly otherRecentFlags: readonly components["schemas"]["InstancePlayerFlag"][];
+    };
+    readonly PlayerBlacklistedInstance: {
+      /** Format: int64 */
+      readonly instanceId: string;
+      /** Format: date-time */
+      readonly instanceDate: string;
+      readonly reason: string;
+      readonly individualReason: string | null;
+      /** Format: date-time */
+      readonly createdAt: string;
+    };
+    readonly ClanBasic: {
+      /** Format: int64 */
+      readonly groupId: string;
+      readonly name: string;
+      readonly callSign: string;
+      readonly motto: string;
+      readonly avatarPath: string | null;
     };
     readonly ClanBannerData: {
       readonly decalId: number;
@@ -2537,13 +3032,6 @@ export interface components {
       readonly totalTimePlayedSeconds: number;
       readonly contestScore: number;
     };
-    readonly ClanStats: {
-      readonly aggregateStats: components["schemas"]["ClanAggregateStats"];
-      readonly members: readonly {
-          readonly playerInfo: components["schemas"]["PlayerInfo"];
-          readonly stats: components["schemas"]["ClanMemberStats"];
-        }[];
-    };
     readonly InstanceMetadata: {
       readonly activityName: string;
       readonly versionName: string;
@@ -2585,11 +3073,6 @@ export interface components {
       readonly playerInfo: components["schemas"]["PlayerInfo"];
       readonly characters: readonly components["schemas"]["InstanceCharacter"][];
     };
-    readonly InstanceExtended: components["schemas"]["Instance"] & ({
-      readonly leaderboardRank: number | null;
-      readonly metadata: components["schemas"]["InstanceMetadata"];
-      readonly players: readonly components["schemas"]["InstancePlayerExtended"][];
-    });
     readonly TeamLeaderboardEntry: {
       readonly position: number;
       readonly rank: number;
@@ -2604,23 +3087,6 @@ export interface components {
       readonly value: number;
       readonly playerInfo: components["schemas"]["PlayerInfo"];
     };
-    readonly LeaderboardData: OneOf<[{
-      /** @enum {string} */
-      readonly type: "team";
-      /** @enum {string} */
-      readonly format: "duration" | "numerical";
-      readonly page: number;
-      readonly count: number;
-      readonly entries: readonly components["schemas"]["TeamLeaderboardEntry"][];
-    }, {
-      /** @enum {string} */
-      readonly type: "individual";
-      /** @enum {string} */
-      readonly format: "duration" | "numerical";
-      readonly page: number;
-      readonly count: number;
-      readonly entries: readonly components["schemas"]["IndividualLeaderboardEntry"][];
-    }]>;
     /** @enum {string} */
     readonly IndividualGlobalLeaderboardCategory: "clears" | "full-clears" | "sherpas" | "speedrun" | "world-first-rankings" | "in-raid-time";
     /** @description Pagination parameters for leaderboard data */
@@ -2709,87 +3175,8 @@ export interface components {
     readonly PopulationByRaidMetric: {
       [key: string]: number;
     };
-    /** @description A raw PGCR with a few redundant fields removed */
-    readonly RaidHubPostGameCarnageReport: {
-      /** Format: date-time */
-      readonly period: string;
-      readonly startingPhaseIndex?: number;
-      readonly activityWasStartedFromBeginning?: boolean;
-      readonly activityDetails: {
-        /** Format: uint32 */
-        readonly directorActivityHash: number;
-        /** Format: int64 */
-        readonly instanceId: string;
-        /** @enum {integer} */
-        readonly mode: 0 | 2 | 3 | 4 | 5 | 6 | 7 | 9 | 10 | 11 | 12 | 13 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31 | 32 | 37 | 38 | 39 | 40 | 41 | 42 | 43 | 44 | 45 | 46 | 47 | 48 | 49 | 50 | 51 | 52 | 53 | 54 | 55 | 56 | 57 | 58 | 59 | 60 | 61 | 62 | 63 | 64 | 65 | 66 | 67 | 68 | 69 | 70 | 71 | 72 | 73 | 74 | 75 | 76 | 77 | 78 | 79 | 80 | 81 | 82 | 83 | 84 | 85 | 86 | 87 | 88 | 89 | 90 | 91;
-        readonly modes: readonly (0 | 2 | 3 | 4 | 5 | 6 | 7 | 9 | 10 | 11 | 12 | 13 | 15 | 16 | 17 | 18 | 19 | 20 | 21 | 22 | 24 | 25 | 26 | 27 | 28 | 29 | 30 | 31 | 32 | 37 | 38 | 39 | 40 | 41 | 42 | 43 | 44 | 45 | 46 | 47 | 48 | 49 | 50 | 51 | 52 | 53 | 54 | 55 | 56 | 57 | 58 | 59 | 60 | 61 | 62 | 63 | 64 | 65 | 66 | 67 | 68 | 69 | 70 | 71 | 72 | 73 | 74 | 75 | 76 | 77 | 78 | 79 | 80 | 81 | 82 | 83 | 84 | 85 | 86 | 87 | 88 | 89 | 90 | 91)[];
-        readonly membershipType: components["schemas"]["DestinyMembershipType"];
-      };
-      readonly activityDifficultyTier?: number;
-      readonly selectedSkullHashes?: readonly number[];
-      readonly entries: readonly ({
-          readonly player: {
-            readonly destinyUserInfo: {
-              readonly iconPath?: string | null;
-              readonly crossSaveOverride: components["schemas"]["DestinyMembershipType"];
-              readonly applicableMembershipTypes?: (readonly components["schemas"]["DestinyMembershipType"][]) | null;
-              readonly membershipType?: components["schemas"]["DestinyMembershipType"];
-              /** Format: int64 */
-              readonly membershipId: string;
-              readonly displayName?: string | null;
-              readonly bungieGlobalDisplayName?: string | null;
-              readonly bungieGlobalDisplayNameCode?: number | null;
-            };
-            readonly characterClass?: string | null;
-            /** Format: uint32 */
-            readonly classHash: number;
-            /** Format: uint32 */
-            readonly raceHash: number;
-            /** Format: uint32 */
-            readonly genderHash: number;
-            readonly characterLevel: number;
-            readonly lightLevel: number;
-            /** Format: uint32 */
-            readonly emblemHash: number;
-          };
-          /** Format: int64 */
-          readonly characterId: string;
-          readonly values: {
-            [key: string]: {
-              readonly basic: {
-                readonly value: number;
-                readonly displayValue: string;
-              };
-            };
-          };
-          readonly extended?: {
-            readonly weapons?: (readonly {
-                readonly referenceId: number;
-                readonly values: {
-                  [key: string]: {
-                    readonly basic: {
-                      readonly value: number;
-                      readonly displayValue: string;
-                    };
-                  };
-                };
-              }[]) | null;
-            readonly values: {
-              [key: string]: {
-                readonly basic: {
-                  readonly value: number;
-                  readonly displayValue: string;
-                };
-              };
-            };
-          };
-        })[];
-    };
     readonly InstanceForPlayer: components["schemas"]["Instance"] & {
       readonly player: components["schemas"]["InstancePlayer"];
-    };
-    readonly InstanceWithPlayers: components["schemas"]["Instance"] & {
-      readonly players: readonly components["schemas"]["PlayerInfo"][];
     };
     readonly PlayerProfileActivityStats: {
       readonly activityId: number;
@@ -2822,18 +3209,6 @@ export interface components {
       readonly isWeekOne: boolean;
       readonly isChallengeMode: boolean;
     };
-    readonly PlayerProfile: {
-      readonly playerInfo: components["schemas"]["PlayerInfo"];
-      readonly stats: {
-        readonly global: components["schemas"]["PlayerProfileGlobalStats"];
-        readonly activity: {
-          [key: string]: components["schemas"]["PlayerProfileActivityStats"];
-        };
-      };
-      readonly worldFirstEntries: {
-        [key: string]: components["schemas"]["WorldFirstEntry"];
-      };
-    };
     readonly Teammate: {
       readonly estimatedTimePlayedSeconds: number;
       readonly clears: number;
@@ -2864,6 +3239,78 @@ export interface components {
       readonly latestResolvedInstance: components["schemas"]["LatestResolvedInstance"];
       /** Format: date-time */
       readonly estimatedBacklogEmptied: string | null;
+    };
+    /** @default {} */
+    readonly DiscordWebhookBody: {
+      readonly name?: string;
+      readonly targets?: {
+        readonly players?: readonly {
+            readonly membershipId: string;
+            readonly requireFresh?: boolean;
+            readonly requireCompleted?: boolean;
+            readonly raids?: readonly number[];
+          }[];
+        readonly clans?: readonly {
+            readonly groupId: string;
+            readonly requireFresh?: boolean;
+            readonly requireCompleted?: boolean;
+            readonly raids?: readonly number[];
+          }[];
+      };
+    };
+    readonly DiscordWebhookPutResponse: {
+      readonly guildId: string;
+      readonly channelId: string;
+      readonly webhookId: string;
+      /** Format: uri */
+      readonly webhookUrl?: string;
+      readonly created: boolean;
+      readonly activated: boolean;
+      readonly updated: boolean;
+      readonly rules: {
+        readonly players: {
+          readonly inserted: number;
+          readonly updated: number;
+        };
+        readonly clans: {
+          readonly inserted: number;
+          readonly updated: number;
+        };
+      };
+    };
+    readonly DiscordWebhookDeleteResponse: {
+      readonly deleted: boolean;
+    };
+    readonly DiscordWebhookStatusResponse: OneOf<[{
+      /** @enum {boolean} */
+      readonly registered: false;
+    }, {
+      /** @enum {boolean} */
+      readonly registered: true;
+      readonly guildId: string;
+      readonly channelId: string;
+      readonly webhookId: string;
+      readonly destinationActive: boolean;
+      readonly consecutiveDeliveryFailures: number;
+      readonly lastDeliverySuccessAt: string | null;
+      readonly lastDeliveryFailureAt: string | null;
+      readonly lastDeliveryError: string | null;
+      readonly players: readonly {
+          readonly membershipId: string;
+          readonly requireFresh: boolean;
+          readonly requireCompleted: boolean;
+          readonly raidIds: readonly number[];
+        }[];
+      readonly clans: readonly {
+          readonly groupId: string;
+          readonly requireFresh: boolean;
+          readonly requireCompleted: boolean;
+          readonly raidIds: readonly number[];
+        }[];
+    }]>;
+    readonly InvalidDiscordAuthError: {
+      /** @enum {string} */
+      readonly message: "Invalid Discord context token";
     };
     readonly ManifestResponse: {
       /** @description The mapping of each Bungie.net hash to a RaidHub activityId and versionId */
@@ -2897,8 +3344,10 @@ export interface components {
       readonly resprisedChallengeVersionIds: readonly number[];
       /** @description The list of activityId for Pantheon */
       readonly pantheonIds: readonly number[];
-      /** @description The list of versionId for Pantheon gauntlet modes (full boss lineup) */
-      readonly gauntletVersionIds: readonly number[];
+      /** @description Active Pantheon versionId values in display order */
+      readonly pantheonVersionIds: readonly number[];
+      /** @description Sunset Pantheon versionId values in display order */
+      readonly pantheonSunsetVersionIds: readonly number[];
       /** @description The set of versionId for each activityId */
       readonly versionsForActivity: {
         [key: string]: readonly number[];
@@ -2926,6 +3375,7 @@ export interface components {
     readonly PlayerSearchResponse: {
       readonly params: {
         readonly count: number;
+        readonly offset: number;
         readonly query: string;
       };
       readonly results: readonly components["schemas"]["PlayerInfo"][];
@@ -2987,7 +3437,9 @@ export interface components {
       };
     };
     readonly PlayerTeammatesResponse: readonly components["schemas"]["Teammate"][];
-    readonly PlayerInstancesResponse: readonly components["schemas"]["InstanceWithPlayers"][];
+    readonly PlayerInstancesResponse: readonly (components["schemas"]["Instance"] & {
+        readonly players: readonly components["schemas"]["PlayerInfo"][];
+      })[];
     readonly PlayerProtectedResourceError: {
       readonly message: string;
       /** Format: int64 */
@@ -3197,6 +3649,14 @@ export interface components {
       readonly message: string;
       readonly route: string;
     };
+    readonly ClanBasicResponse: {
+      /** Format: int64 */
+      readonly groupId: string;
+      readonly name: string;
+      readonly callSign: string;
+      readonly motto: string;
+      readonly avatarPath: string | null;
+    };
     readonly MetricsWeaponsRollingWeekResponse: {
       readonly energy: readonly components["schemas"]["WeaponMetric"][];
       readonly kinetic: readonly components["schemas"]["WeaponMetric"][];
@@ -3244,7 +3704,11 @@ export interface components {
       readonly instanceId: string;
       readonly players: readonly string[];
     };
-    readonly AdminReportingPlayerResponse: string;
+    readonly AdminReportingPlayerResponse: {
+      readonly playerInfo: components["schemas"]["PlayerInfo"];
+      readonly recentFlags: readonly components["schemas"]["InstancePlayerFlag"][];
+      readonly blacklistedInstances: readonly components["schemas"]["PlayerBlacklistedInstance"][];
+    };
     readonly AuthorizeAdminResponse: {
       readonly value: string;
       /** Format: date-time */
@@ -3256,6 +3720,33 @@ export interface components {
       /** Format: date-time */
       readonly expires: string;
     };
+    readonly SubscriptionsDiscordWebhooksResponse: OneOf<[{
+      /** @enum {boolean} */
+      readonly registered: false;
+    }, {
+      /** @enum {boolean} */
+      readonly registered: true;
+      readonly guildId: string;
+      readonly channelId: string;
+      readonly webhookId: string;
+      readonly destinationActive: boolean;
+      readonly consecutiveDeliveryFailures: number;
+      readonly lastDeliverySuccessAt: string | null;
+      readonly lastDeliveryFailureAt: string | null;
+      readonly lastDeliveryError: string | null;
+      readonly players: readonly {
+          readonly membershipId: string;
+          readonly requireFresh: boolean;
+          readonly requireCompleted: boolean;
+          readonly raidIds: readonly number[];
+        }[];
+      readonly clans: readonly {
+          readonly groupId: string;
+          readonly requireFresh: boolean;
+          readonly requireCompleted: boolean;
+          readonly raidIds: readonly number[];
+        }[];
+    }]>;
   };
   responses: never;
   parameters: {

--- a/src/services/raidhub/types.ts
+++ b/src/services/raidhub/types.ts
@@ -45,8 +45,8 @@ export type RaidHubFeatDefinition = Component<"FeatDefinition">
 
 export type RaidHubPlayerInfo = Component<"PlayerInfo">
 export type RaidHubInstance = Component<"Instance">
-export type RaidHubInstanceExtended = Component<"InstanceExtended">
-export type RaidHubInstanceWithPlayers = Component<"InstanceWithPlayers">
+export type RaidHubInstanceExtended = Component<"InstanceResponse">
+export type RaidHubInstanceWithPlayers = Component<"PlayerInstancesResponse">[number]
 export type RaidHubInstancePlayerExtended = Component<"InstancePlayerExtended">
 export type RaidHubInstanceCharacter = Component<"InstanceCharacter">
 export type RaidHubInstanceForPlayer = Component<"InstanceForPlayer">
@@ -55,7 +55,7 @@ export type RaidHubClanMemberStats = Component<"ClanMemberStats">
 
 export type RaidHubWeaponMetric = Component<"WeaponMetric">
 
-export type RaidHubLeaderboardData = Component<"LeaderboardData">
+export type RaidHubLeaderboardData = Component<"LeaderboardIndividualGlobalResponse">
 export type RaidHubIndividualLeaderboardEntry = Component<"IndividualLeaderboardEntry">
 
 export type RaidHubLeaderboardURL = RaidHubGetPath &


### PR DESCRIPTION
## Summary

Website layer for Pantheon 2.0 — one flat grid of boss versions, Adventure badge on PGCR only.

- Consumes `pantheonVersionIds` and `pantheonSunsetVersionIds` from `/manifest` (replaces `gauntletVersionIds`)
- Removes gauntlet/boss split from profile layout, home page links, and manifest manager
- One flat grid of active Pantheon modes (**132–141**); **Historical Modes** section for sunset EP bosses (**128–131**)
- Fixes Pantheon card splashes (`raidId` = activity id, `versionId` = boss version) and fallback CDN image path (`large.png`)
- Shows **Adventure** badge on PGCR when `difficultyTier === 'adventure'`; no UI distinction for Standard vs Custom

**Model:** Card titles and PGCR version badge use boss `versionName`. `difficultyTier` only adds the Adventure badge — it does not rename versions.

## Related PRs

| Repo | PR | Role |
|------|-----|------|
| Services | [#48](https://github.com/Raid-Hub/Services/pull/48) | Seeds + production SQL + PGCR skull dedupe |
| API | [#133](https://github.com/Raid-Hub/API/pull/133) | Manifest lists + query-time `difficultyTier` |
| **Website** | **#325** (this) | Flat pantheon UI + Adventure badge |

## Deploy order

1. Merge and deploy Services [#48](https://github.com/Raid-Hub/Services/pull/48) + run production SQL + refresh pantheon MV
2. Deploy API [#133](https://github.com/Raid-Hub/API/pull/133)
3. Deploy **this PR**

## Test plan

- [ ] Pantheon profile shows all active versions (132–141) in one grid with splash images
- [ ] Card titles show boss names (no `undefined`)
- [ ] Historical Modes section shows sunset EP bosses (128–131)
- [ ] Home page Pantheon links list all active versions (no gauntlet subsection)
- [ ] Individual pantheon leaderboards resolve version paths correctly
- [ ] PGCR for Adventure pantheon run shows Adventure badge; Standard/Custom runs do not