### PR TITLE
Fix missing historical pantheon links on home page

### DIFF
--- a/src/app/leaderboards/team/[raid]/first/[version]/page.tsx
+++ b/src/app/leaderboards/team/[raid]/first/[version]/page.tsx
@@ -2,6 +2,7 @@ import { type Metadata } from "next"
 import { notFound } from "next/navigation"
 import { LeaderboardSSR } from "~/app/leaderboards/LeaderboardSSR"
 import { CloudflareActivitySplash } from "~/components/CloudflareImage"
+import { findPantheonVersionByPath } from "~/lib/manifest/pantheon"
 import { baseMetadata } from "~/lib/metadata"
 import { prefetchManifest } from "~/services/raidhub/prefetchRaidHubManifest"
 import { type RaidHubManifestResponse } from "~/services/raidhub/types"
@@ -22,22 +23,35 @@ type DynamicParams = {
 }
 
 const getDefinitions = (params: DynamicParams["params"], manifest: RaidHubManifestResponse) => {
+    if (params.raid === "pantheon") {
+        const version = findPantheonVersionByPath(manifest, params.version) ?? notFound()
+        const activity =
+            manifest.activityDefinitions[version.associatedActivityId!] ?? notFound()
+
+        return { version, activity, isPantheon: true as const }
+    }
+
     return {
         version:
             Object.values(manifest.versionDefinitions).find(def => def.path === params.version) ??
             notFound(),
         activity:
             Object.values(manifest.activityDefinitions).find(def => def.path === params.raid) ??
-            notFound()
+            notFound(),
+        isPantheon: false as const
     }
 }
 
 export async function generateMetadata({ params }: DynamicParams): Promise<Metadata> {
     const manifest = await prefetchManifest()
-    const { version, activity } = getDefinitions(params, manifest)
+    const { version, activity, isPantheon } = getDefinitions(params, manifest)
 
-    const title = `${version.name} ${activity.name} First Completions Leaderboard`
-    const description = `View the first completions for ${version.name} ${activity.name}`
+    const title = isPantheon
+        ? `${activity.name}: ${version.name} First Completions Leaderboard`
+        : `${version.name} ${activity.name} First Completions Leaderboard`
+    const description = isPantheon
+        ? `View the first completions for ${version.name} in ${activity.name}`
+        : `View the first completions for ${version.name} ${activity.name}`
 
     return {
         title: title,
@@ -59,15 +73,24 @@ export async function generateMetadata({ params }: DynamicParams): Promise<Metad
 
 export default async function Page({ params, searchParams }: DynamicParams) {
     const manifest = await prefetchManifest()
-    const { version, activity } = getDefinitions(params, manifest)
+    const { version, activity, isPantheon } = getDefinitions(params, manifest)
     return (
         <Leaderboard
             heading={
                 <Splash
-                    title="First Completions Leaderboard"
-                    subtitle={`${version.name} ${activity.name}`}
-                    tertiaryTitle="First Completion Leaderboards">
-                    <CloudflareActivitySplash activityId={activity.id} fill className="z-[-1]" />
+                    tertiaryTitle={
+                        isPantheon ? activity.name : "First Completion Leaderboards"
+                    }
+                    title={isPantheon ? version.name : "First Completions Leaderboard"}
+                    subtitle={
+                        isPantheon ? "First Completions Leaderboard" : `${version.name} ${activity.name}`
+                    }>
+                    <CloudflareActivitySplash
+                        activityId={isPantheon ? version.associatedActivityId! : activity.id}
+                        versionId={isPantheon ? version.id : undefined}
+                        fill
+                        className="z-[-1]"
+                    />
                 </Splash>
             }
             hasPages

--- a/src/app/leaderboards/team/[raid]/first/[version]/page.tsx
+++ b/src/app/leaderboards/team/[raid]/first/[version]/page.tsx
@@ -25,8 +25,7 @@ type DynamicParams = {
 const getDefinitions = (params: DynamicParams["params"], manifest: RaidHubManifestResponse) => {
     if (params.raid === "pantheon") {
         const version = findPantheonVersionByPath(manifest, params.version) ?? notFound()
-        const activity =
-            manifest.activityDefinitions[version.associatedActivityId!] ?? notFound()
+        const activity = manifest.activityDefinitions[version.associatedActivityId!] ?? notFound()
 
         return { version, activity, isPantheon: true as const }
     }
@@ -78,12 +77,12 @@ export default async function Page({ params, searchParams }: DynamicParams) {
         <Leaderboard
             heading={
                 <Splash
-                    tertiaryTitle={
-                        isPantheon ? activity.name : "First Completion Leaderboards"
-                    }
+                    tertiaryTitle={isPantheon ? activity.name : "First Completion Leaderboards"}
                     title={isPantheon ? version.name : "First Completions Leaderboard"}
                     subtitle={
-                        isPantheon ? "First Completions Leaderboard" : `${version.name} ${activity.name}`
+                        isPantheon
+                            ? "First Completions Leaderboard"
+                            : `${version.name} ${activity.name}`
                     }>
                     <CloudflareActivitySplash
                         activityId={isPantheon ? version.associatedActivityId! : activity.id}

--- a/src/components/home/HomeBuckets.tsx
+++ b/src/components/home/HomeBuckets.tsx
@@ -308,11 +308,22 @@ function PantheonModeLinks({
 }
 
 function PantheonLinks() {
-    const { activePantheonVersions } = useRaidHubManifest()
+    const { activePantheonVersions, pantheonSunsetVersions } = useRaidHubManifest()
 
     return (
         <div>
-            <PantheonModeLinks versions={activePantheonVersions} keyPrefix="pantheon" />
+            <PantheonModeLinks versions={activePantheonVersions} keyPrefix="pantheon-active" />
+            {pantheonSunsetVersions.length > 0 && (
+                <div className="mt-6">
+                    <h3 className="text-secondary mb-3 text-sm font-semibold tracking-wide uppercase">
+                        Historical Modes
+                    </h3>
+                    <PantheonModeLinks
+                        versions={pantheonSunsetVersions}
+                        keyPrefix="pantheon-historical"
+                    />
+                </div>
+            )}
         </div>
     )
 }


### PR DESCRIPTION
## Summary

- Home page Pantheon bucket only listed `activePantheonVersions`, dropping sunset EP bosses (128–131). Adds **Historical Modes** using `pantheonSunsetVersionIds`.
- Pantheon team first-completion leaderboard showed jumbled subtitle **"Insurrection Prime Revolutionary The Pantheon"**. Now matches individual pantheon layout: activity name → boss name → "First Completions Leaderboard". Uses `findPantheonVersionByPath` for correct activity 101/102 resolution.

## Test plan

- [ ] Home Pantheon section lists active versions + Historical Modes (Atraks, Oryx, Rhulk, Nezarec)
- [ ] `/leaderboards/team/pantheon/first/insurrection-revolutionary` shows boss name as title, not concatenated with activity name
- [ ] Sunset pantheon first-completion pages resolve correctly (activity 101)