### PR TITLE
Fix PGCR header crash when splash URLs are missing

### DIFF
--- a/src/components/pgcr/pgcr-header-bg.tsx
+++ b/src/components/pgcr/pgcr-header-bg.tsx
@@ -15,7 +15,7 @@ export const PGCRHeaderBackground = ({
     const imageVariants = getImageVariantsForActivity(activityId)
     const variant = imageVariants.find(v => v.size === "small") ?? imageVariants[0]
 
-    const backgroundImageUrl = variant.url ?? FallbackSplash
+    const backgroundImageUrl = variant?.url ?? FallbackSplash
     return (
         <div
             className="relative min-h-44 overflow-hidden rounded-t-lg bg-cover bg-center md:h-48"


### PR DESCRIPTION
## Summary
- Use optional chaining when resolving the PGCR header background splash image so missing manifest `splashUrls` fall back to the generic image instead of crashing the page

## Context
`/pgcr/16871003329` crashed with `Cannot read properties of undefined (reading 'url')` because `splashUrls[102]` was empty in production. `CloudflareActivitySplash` already handled this; `PGCRHeaderBackground` did not.

## Test plan
- [ ] Open a Pantheon PGCR page and confirm it renders (with splash or fallback)
- [ ] Confirm raid PGCR pages still show correct splash backgrounds


Made with [Cursor](https://cursor.com)