### PR TITLE
Redesign homepage leaderboard cards and add pantheon community race

### DIFF
--- a/src/app/(home)/page.tsx
+++ b/src/app/(home)/page.tsx
@@ -22,9 +22,11 @@ export async function generateMetadata() {
 }
 export default async function Page() {
     return (
-        <PageWrapper className="space-y-6">
-            <HomeLogo />
-            <HomeSearchButton />
+        <PageWrapper className="mx-auto flex max-w-[120rem] flex-col gap-6 py-2">
+            <div className="flex flex-col items-center gap-4">
+                <HomeLogo />
+                <HomeSearchButton />
+            </div>
             <HomeQuickLinks />
             <Buckets />
         </PageWrapper>

--- a/src/app/leaderboards/LeaderboardControls.tsx
+++ b/src/app/leaderboards/LeaderboardControls.tsx
@@ -41,6 +41,7 @@ export const LeaderboardControls = (props: { hasPages: boolean; hasSearch: boole
                 throw new Error("This function should not be called when search is enabled")
             }
 
+            // @ts-expect-error generic hell
             return await getRaidHubApi(apiUrl, params, {
                 search: membershipId,
                 count: entriesPerPage

--- a/src/app/leaderboards/team/custom/pantheon-community-race/page.tsx
+++ b/src/app/leaderboards/team/custom/pantheon-community-race/page.tsx
@@ -12,15 +12,13 @@ export const revalidate = 900
 export const dynamic = "force-static"
 export const fetchCache = "default-no-store"
 
-const COMMUNITY_RACE_VERSION_ID = 134
-
 export async function generateMetadata(): Promise<Metadata> {
     const manifest = await prefetchManifest()
     const activityId = getActivePantheonIds(manifest)[0]
     const activity = activityId != null ? manifest.activityDefinitions[activityId] : undefined
     const version = manifest.versionDefinitions[PANTHEON_COMMUNITY_RACE_VERSION_ID]
 
-    if (!activity || !version || version.associatedActivityId == null) {
+    if (!activity || version?.associatedActivityId == null) {
         notFound()
     }
 
@@ -51,7 +49,7 @@ export default async function Page({ searchParams }: { searchParams: Record<stri
     const activity = activityId != null ? manifest.activityDefinitions[activityId] : undefined
     const version = manifest.versionDefinitions[PANTHEON_COMMUNITY_RACE_VERSION_ID]
 
-    if (!activity || !version || version.associatedActivityId == null) {
+    if (!activity || version?.associatedActivityId == null) {
         notFound()
     }
 

--- a/src/app/leaderboards/team/custom/pantheon-community-race/page.tsx
+++ b/src/app/leaderboards/team/custom/pantheon-community-race/page.tsx
@@ -1,0 +1,93 @@
+import { type Metadata } from "next"
+import { notFound } from "next/navigation"
+import { LeaderboardSSR } from "~/app/leaderboards/LeaderboardSSR"
+import { CloudflareActivitySplash } from "~/components/CloudflareImage"
+import { getActivePantheonIds } from "~/lib/manifest/pantheon"
+import { baseMetadata } from "~/lib/metadata"
+import { prefetchManifest } from "~/services/raidhub/prefetchRaidHubManifest"
+import { Leaderboard } from "../../../Leaderboard"
+import { Splash } from "../../../LeaderboardSplashComponents"
+
+export const revalidate = 900
+export const dynamic = "force-static"
+export const fetchCache = "default-no-store"
+
+const COMMUNITY_RACE_VERSION_ID = 134
+
+export async function generateMetadata(): Promise<Metadata> {
+    const manifest = await prefetchManifest()
+    const activityId = getActivePantheonIds(manifest)[0]
+    const activity =
+        activityId != null ? manifest.activityDefinitions[activityId] : undefined
+    const version = manifest.versionDefinitions[COMMUNITY_RACE_VERSION_ID]
+
+    if (!activity || !version) {
+        notFound()
+    }
+
+    const title = `${activity.name}: ${version.name} Community Race Leaderboard`
+    const description = `View community race placements for ${version.name} in ${activity.name}`
+
+    return {
+        title,
+        description,
+        keywords: [activity.name, version.name, "community race", "pantheon", ...baseMetadata.keywords],
+        openGraph: {
+            ...baseMetadata.openGraph,
+            title,
+            description
+        }
+    }
+}
+
+export default async function Page({
+    searchParams
+}: {
+    searchParams: Record<string, string>
+}) {
+    const manifest = await prefetchManifest()
+    const activityId = getActivePantheonIds(manifest)[0]
+    const activity =
+        activityId != null ? manifest.activityDefinitions[activityId] : undefined
+    const version = manifest.versionDefinitions[COMMUNITY_RACE_VERSION_ID]
+
+    if (!activity || !version) {
+        notFound()
+    }
+
+    return (
+        <Leaderboard
+            heading={
+                <Splash
+                    tertiaryTitle={activity.name}
+                    title={version.name}
+                    subtitle="Community Race Leaderboard">
+                    <CloudflareActivitySplash
+                        activityId={version.associatedActivityId!}
+                        versionId={version.id}
+                        fill
+                        className="z-[-1]"
+                    />
+                </Splash>
+            }
+            hasPages
+            hasSearch
+            external={false}
+            pageProps={{
+                layout: "team",
+                queryKey: ["raidhub", "leaderboard", "pantheon-community-race"],
+                entriesPerPage: 50,
+                apiUrl: "/leaderboard/team/custom/pantheon-community-race",
+                params: null
+            }}
+            entries={
+                <LeaderboardSSR
+                    page={searchParams.page ?? "1"}
+                    entriesPerPage={50}
+                    apiUrl="/leaderboard/team/custom/pantheon-community-race"
+                    params={null}
+                />
+            }
+        />
+    )
+}

--- a/src/app/leaderboards/team/custom/pantheon-community-race/page.tsx
+++ b/src/app/leaderboards/team/custom/pantheon-community-race/page.tsx
@@ -2,7 +2,7 @@ import { type Metadata } from "next"
 import { notFound } from "next/navigation"
 import { LeaderboardSSR } from "~/app/leaderboards/LeaderboardSSR"
 import { CloudflareActivitySplash } from "~/components/CloudflareImage"
-import { getActivePantheonIds } from "~/lib/manifest/pantheon"
+import { getActivePantheonIds, PANTHEON_COMMUNITY_RACE_VERSION_ID } from "~/lib/manifest/pantheon"
 import { baseMetadata } from "~/lib/metadata"
 import { prefetchManifest } from "~/services/raidhub/prefetchRaidHubManifest"
 import { Leaderboard } from "../../../Leaderboard"
@@ -17,11 +17,10 @@ const COMMUNITY_RACE_VERSION_ID = 134
 export async function generateMetadata(): Promise<Metadata> {
     const manifest = await prefetchManifest()
     const activityId = getActivePantheonIds(manifest)[0]
-    const activity =
-        activityId != null ? manifest.activityDefinitions[activityId] : undefined
-    const version = manifest.versionDefinitions[COMMUNITY_RACE_VERSION_ID]
+    const activity = activityId != null ? manifest.activityDefinitions[activityId] : undefined
+    const version = manifest.versionDefinitions[PANTHEON_COMMUNITY_RACE_VERSION_ID]
 
-    if (!activity || !version) {
+    if (!activity || !version || version.associatedActivityId == null) {
         notFound()
     }
 
@@ -31,7 +30,13 @@ export async function generateMetadata(): Promise<Metadata> {
     return {
         title,
         description,
-        keywords: [activity.name, version.name, "community race", "pantheon", ...baseMetadata.keywords],
+        keywords: [
+            activity.name,
+            version.name,
+            "community race",
+            "pantheon",
+            ...baseMetadata.keywords
+        ],
         openGraph: {
             ...baseMetadata.openGraph,
             title,
@@ -40,18 +45,13 @@ export async function generateMetadata(): Promise<Metadata> {
     }
 }
 
-export default async function Page({
-    searchParams
-}: {
-    searchParams: Record<string, string>
-}) {
+export default async function Page({ searchParams }: { searchParams: Record<string, string> }) {
     const manifest = await prefetchManifest()
     const activityId = getActivePantheonIds(manifest)[0]
-    const activity =
-        activityId != null ? manifest.activityDefinitions[activityId] : undefined
-    const version = manifest.versionDefinitions[COMMUNITY_RACE_VERSION_ID]
+    const activity = activityId != null ? manifest.activityDefinitions[activityId] : undefined
+    const version = manifest.versionDefinitions[PANTHEON_COMMUNITY_RACE_VERSION_ID]
 
-    if (!activity || !version) {
+    if (!activity || !version || version.associatedActivityId == null) {
         notFound()
     }
 
@@ -63,7 +63,7 @@ export default async function Page({
                     title={version.name}
                     subtitle="Community Race Leaderboard">
                     <CloudflareActivitySplash
-                        activityId={version.associatedActivityId!}
+                        activityId={version.associatedActivityId}
                         versionId={version.id}
                         fill
                         className="z-[-1]"

--- a/src/components/CloudflareImage.tsx
+++ b/src/components/CloudflareImage.tsx
@@ -126,31 +126,38 @@ export const CloudflareActivitySplash = ({
     alt,
     ...props
 }: { activityId: number; versionId?: number } & StrippedImageProps) => {
-    const { getImageVariantsForActivity, getActivityDefinition, getVersionString } =
-        useRaidHubManifest()
+    const {
+        getImageVariantsForActivity,
+        getImageVariantsForVersion,
+        getActivityDefinition,
+        getVersionString
+    } = useRaidHubManifest()
 
     const loader = useCallback<ImageLoader>(
         ({ width, quality }) => {
             // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing
             const minWidth = (width * (quality || 75)) / 100
 
-            const activityVariants = getImageVariantsForActivity(activityId)
-            if (!activityVariants?.length) {
+            const splashVariants =
+                versionId != null
+                    ? getImageVariantsForVersion(versionId)
+                    : getImageVariantsForActivity(activityId)
+            if (!splashVariants.length) {
                 return FallbackSplash
             }
 
-            const availableSizes = new Set(activityVariants.map(c => c.size))
+            const availableSizes = new Set(splashVariants.map(c => c.size))
 
             const variants = cloudflareVariants.filter(item => availableSizes.has(item.name))
             const size = (
                 variants.find(item => item.w >= minWidth && availableSizes.has(item.name)) ??
                 variants[variants.length - 1]
             ).name
-            const content = activityVariants.find(c => c.size === size)!
+            const content = splashVariants.find(c => c.size === size)!
 
             return content.url
         },
-        [activityId, getImageVariantsForActivity]
+        [activityId, versionId, getImageVariantsForActivity, getImageVariantsForVersion]
     )
 
     const activityDefinition = getActivityDefinition(activityId)

--- a/src/components/CloudflareImage.tsx
+++ b/src/components/CloudflareImage.tsx
@@ -4,6 +4,7 @@ import Image, { type ImageLoader } from "next/image"
 import { useCallback, type ComponentPropsWithoutRef } from "react"
 import { HomePageSplash } from "~/lib/activity-images"
 import { VaultEmblems } from "~/lib/bungie-foundation-emblems"
+import { cn } from "~/lib/tw"
 import { type ImageSize } from "~/services/raidhub/types"
 import { useRaidHubManifest } from "./providers/RaidHubManifestManager"
 
@@ -159,5 +160,13 @@ export const CloudflareActivitySplash = ({
             ? activityDefinition.name
             : getVersionString(versionId ?? activityId))
 
-    return <Image loader={loader} {...props} src="placeholder" alt={altText} />
+    return (
+        <Image
+            loader={loader}
+            {...props}
+            className={cn(props.fill && "object-cover object-[center_30%]", props.className)}
+            src="placeholder"
+            alt={altText}
+        />
+    )
 }

--- a/src/components/home/HomeBuckets.tsx
+++ b/src/components/home/HomeBuckets.tsx
@@ -1,329 +1,339 @@
 "use client"
 
+import { ChevronRight } from "lucide-react"
 import Link from "next/link"
-import { Fragment, useState } from "react"
+import { useMemo, useState } from "react"
 import { useRaidHubManifest } from "~/components/providers/RaidHubManifestManager"
 import { SpeedrunVariables } from "~/lib/speedrun/speedrun-com-mappings"
 import { cn } from "~/lib/tw"
+import type { RaidHubActivityDefinition } from "~/services/raidhub/types"
 import { Card, CardContent, CardHeader, CardTitle } from "~/shad/card"
-import { CloudflareStaticImage, type CloudflareStaticImageId } from "../CloudflareImage"
+import { CloudflareActivitySplash } from "../CloudflareImage"
 
-const BucketData: { title: string; splash: CloudflareStaticImageId; Layout: () => JSX.Element }[] =
-    [
-        {
-            title: "World First Leaderboards",
-            splash: "worldFirstSplash",
-            Layout: WorldFirstLinks
-        },
-        {
-            title: "Clears Leaderboards",
-            splash: "genericRaidSplash",
-            Layout: ClearsLinks
-        },
-        {
-            title: "Sherpa Leaderboards",
-            splash: "raidhubCitySplash",
-            Layout: SherpaLinks
-        },
-        {
-            title: "Speedrun Leaderboards",
-            splash: "speedrunPanelSplash",
-            Layout: SpeedrunLinks
-        },
-        {
-            title: "Misc Race Leaderboards",
-            splash: "genericRaidSplash",
-            Layout: VersionFirstLinks
-        },
-        {
-            title: "Pantheon",
-            splash: "genericRaidSplash",
-            Layout: PantheonLinks
-        }
-    ]
+type LinkItem = { href: string; label: string; accent?: "gold" }
+type LinkSection = { title: string; links: LinkItem[] }
+
+const cardClass =
+    "border-border/50 bg-card/40 flex h-full flex-col gap-0 overflow-hidden rounded-lg py-0 shadow-sm"
+const headerClass = "relative h-28 cursor-pointer p-0 md:cursor-default"
+const contentClass =
+    "divide-border/40 bg-background/20 divide-y overflow-hidden p-0 transition-all duration-200 md:block"
+const rowClass =
+    "hover:bg-raidhub/5 group flex items-center justify-between gap-3 px-4 py-2 transition-colors"
 
 export const Buckets = () => {
+    const {
+        listedRaidIds,
+        pantheonIds,
+        activePantheonIds,
+        activePantheonVersions,
+        pantheonSunsetVersions,
+        getActivityDefinition
+    } = useRaidHubManifest()
+
+    const raids = useMemo(
+        () =>
+            listedRaidIds
+                .filter(id => !pantheonIds.includes(id))
+                .toSorted((a, b) => b - a)
+                .map(id => getActivityDefinition(id))
+                .filter((raid): raid is RaidHubActivityDefinition => raid != null),
+        [listedRaidIds, pantheonIds, getActivityDefinition]
+    )
+
+    const epicDpIndex = raids.findIndex(raid => raid.path === "desertperpetualepic")
+    const raidsBeforeEpic = epicDpIndex === -1 ? raids : raids.slice(0, epicDpIndex)
+    const raidsFromEpic = epicDpIndex === -1 ? [] : raids.slice(epicDpIndex)
+
+    const sunsetPantheonId = useMemo(
+        () => pantheonIds.find(id => getActivityDefinition(id)?.isSunset) ?? null,
+        [pantheonIds, getActivityDefinition]
+    )
+
     return (
-        <div className="4xl:grid-cols-4 grid gap-6 lg:grid-cols-2 2xl:grid-cols-3">
-            {BucketData.map(bucket => (
-                <Bucket key={bucket.title} {...bucket} />
+        <div className="grid items-stretch gap-3 sm:gap-4 [grid-template-columns:repeat(auto-fill,minmax(min(100%,22rem),1fr))]">
+            {raidsBeforeEpic.map(raid => (
+                <RaidCard key={raid.id} raid={raid} />
             ))}
+            {activePantheonVersions.length > 0 && (
+                <PantheonCard
+                    activityId={activePantheonIds[0] ?? null}
+                    versions={activePantheonVersions}
+                    includeCommunityRace
+                />
+            )}
+            {raidsFromEpic.map(raid => (
+                <RaidCard key={raid.id} raid={raid} />
+            ))}
+            {pantheonSunsetVersions.length > 0 && (
+                <PantheonCard activityId={sunsetPantheonId} versions={pantheonSunsetVersions} />
+            )}
         </div>
     )
 }
 
-function Bucket({ title, splash, Layout }: (typeof BucketData)[number]) {
-    // State for mobile expand/collapse
-    const [expanded, setExpanded] = useState(false)
+function formatReleaseDate(iso: string | null | undefined): string | null {
+    if (!iso) return null
 
-    const handleToggle = () => {
-        setExpanded(e => !e)
-    }
+    return new Date(iso).toLocaleDateString("en-US", {
+        month: "long",
+        day: "numeric",
+        year: "numeric"
+    })
+}
+
+function SplashHeader({
+    title,
+    activityId,
+    releaseDate,
+    expanded,
+    onToggle
+}: {
+    title: string
+    activityId?: number | null
+    releaseDate?: string | null
+    expanded: boolean
+    onToggle: () => void
+}) {
+    const formattedReleaseDate = formatReleaseDate(releaseDate)
 
     return (
-        <Card key={title} className="gap-0">
-            <CardHeader
-                className="relative aspect-[5/1] cursor-pointer md:cursor-default"
-                onClick={handleToggle}>
-                <CloudflareStaticImage
-                    priority
-                    fill
-                    cloudflareId={splash}
+        <CardHeader className={headerClass} onClick={onToggle}>
+            {activityId ? (
+                <CloudflareActivitySplash
+                    activityId={activityId}
                     alt=""
-                    className="object-cover object-[50%_35%] brightness-75"
+                    fill
+                    className="object-cover object-[center_30%] brightness-[0.7]"
                 />
-                <CardTitle className="z-1 text-center text-lg font-extrabold whitespace-nowrap uppercase text-shadow-lg text-shadow-zinc-800 md:text-2xl lg:absolute lg:bottom-4 lg:left-4">
+            ) : (
+                <div className="bg-muted h-full w-full" />
+            )}
+            <div className="absolute inset-0 bg-gradient-to-t from-black/95 via-black/60 to-black/20" />
+            <div className="absolute right-10 bottom-3 left-4 z-1 flex min-w-0 flex-col gap-0.5">
+                {formattedReleaseDate ? (
+                    <span className="text-[10px] font-normal tracking-wide text-white/30 uppercase tabular-nums drop-shadow-md">
+                        {formattedReleaseDate}
+                    </span>
+                ) : null}
+                <CardTitle className="truncate text-lg font-bold text-white/95 drop-shadow-md">
                     {title}
                 </CardTitle>
-            </CardHeader>
+            </div>
+            <ChevronRight
+                className={cn(
+                    "absolute right-4 bottom-3.5 z-1 size-4 text-white/70 transition-transform md:hidden",
+                    expanded && "rotate-90"
+                )}
+            />
+        </CardHeader>
+    )
+}
 
+function LinkRow({ href, label, accent }: LinkItem) {
+    const isGold = accent === "gold"
+
+    return (
+        <Link href={href} className={cn(rowClass, isGold && "hover:bg-raidhub/8")}>
+            <span
+                className={cn(
+                    "min-w-0 text-sm transition-colors",
+                    isGold
+                        ? "text-raidhub/65 group-hover:text-raidhub"
+                        : "text-muted-foreground group-hover:text-raidhub"
+                )}>
+                {label}
+            </span>
+            <ChevronRight
+                className={cn(
+                    "size-3.5 shrink-0 transition-colors",
+                    isGold
+                        ? "text-raidhub/45 group-hover:text-raidhub"
+                        : "text-muted-foreground/50 group-hover:text-raidhub"
+                )}
+            />
+        </Link>
+    )
+}
+
+function SplitLinkSection({ title, links }: LinkSection) {
+    return (
+        <div className="border-border/40 flex border-b last:border-b-0">
+            <div className="border-border/40 bg-muted/15 text-secondary flex w-[42%] shrink-0 items-center border-r px-4 py-2 text-sm leading-snug">
+                {title}
+            </div>
+            <div className="divide-border/40 bg-background/10 flex min-w-0 flex-1 flex-col divide-y">
+                {links.map(link => (
+                    <LinkRow key={link.href} {...link} />
+                ))}
+            </div>
+        </div>
+    )
+}
+
+function RaidCard({ raid }: { raid: RaidHubActivityDefinition }) {
+    const { resprisedRaidIds, getVersionsForActivity } = useRaidHubManifest()
+    const [expanded, setExpanded] = useState(false)
+    const sections = useMemo(
+        () => buildRaidSections(raid, resprisedRaidIds, getVersionsForActivity),
+        [raid, resprisedRaidIds, getVersionsForActivity]
+    )
+
+    return (
+        <Card className={cardClass}>
+            <SplashHeader
+                title={raid.name}
+                activityId={raid.id}
+                releaseDate={raid.releaseDate}
+                expanded={expanded}
+                onToggle={() => setExpanded(e => !e)}
+            />
             <CardContent
                 className={cn(
-                    "overflow-hidden transition-all duration-200 md:pt-2",
+                    contentClass,
+                    "flex flex-1 flex-col divide-y-0",
                     expanded
-                        ? "max-md:max-h-[1000px] max-md:opacity-100"
-                        : "max-md:h-0 max-md:max-h-0 max-md:p-0 max-md:opacity-0"
+                        ? "max-md:max-h-[2000px] max-md:opacity-100"
+                        : "max-md:h-0 max-md:max-h-0 max-md:opacity-0"
                 )}>
-                <Layout />
+                {sections.map(section => (
+                    <SplitLinkSection key={section.title} {...section} />
+                ))}
             </CardContent>
         </Card>
     )
 }
 
-function WorldFirstLinks() {
-    const { listedRaidIds, getActivityDefinition } = useRaidHubManifest()
+const PANTHEON_COMMUNITY_RACE_VERSION_PATH = "insurrection-revolutionary"
 
-    return (
-        <ul className="space-y-1">
-            {listedRaidIds
-                .toSorted((a, b) => b - a)
-                .map(raidId => {
-                    const raidDef = getActivityDefinition(raidId)
-                    if (!raidDef) return null
-
-                    return (
-                        <li key={raidId}>
-                            <Link
-                                href={`/leaderboards/team/${raidDef.path}/worldfirst`}
-                                className="text-raidhub text-lg hover:underline">
-                                {raidDef.name}
-                            </Link>
-                        </li>
-                    )
-                })}
-        </ul>
-    )
+const PANTHEON_COMMUNITY_RACE_LINK: LinkItem = {
+    href: "/leaderboards/team/custom/pantheon-community-race",
+    label: "Community Race",
+    accent: "gold"
 }
 
-function SpeedrunLinks() {
-    const { listedRaidIds, getActivityDefinition } = useRaidHubManifest()
-
-    return (
-        <ul className="space-y-1">
-            {listedRaidIds
-                .toSorted((a, b) => b - a)
-                .map(raidId => {
-                    const raidDef = getActivityDefinition(raidId)
-                    if (!raidDef) return null
-
-                    const srcVar = SpeedrunVariables[raidDef.path]?.variable
-
-                    if (!srcVar)
-                        return (
-                            <li key={raidId}>
-                                <h3 className="mx-4 inline font-bold">{raidDef.name}</h3>
-                                <Link
-                                    href={`/leaderboards/team/${raidDef.path}/speedrun/any`}
-                                    target="_blank"
-                                    className="text-raidhub text-lg hover:underline">
-                                    Any %
-                                </Link>
-                            </li>
-                        )
-
-                    return (
-                        <li key={raidId}>
-                            <h3 className="mx-4 inline font-bold">{raidDef.name}</h3>
-                            {Object.entries(srcVar.values).map(([type, data], idx, arr) => (
-                                <Fragment key={data.id}>
-                                    <Link
-                                        href={`/leaderboards/team/${raidDef.path}/speedrun/${type}`}
-                                        className="text-raidhub text-lg hover:underline">
-                                        {data.displayName}
-                                    </Link>
-                                    {idx < arr.length - 1 && (
-                                        <span className="text-secondary"> • </span>
-                                    )}
-                                </Fragment>
-                            ))}
-                        </li>
-                    )
-                })}
-        </ul>
-    )
-}
-
-function ClearsLinks() {
-    const { listedRaidIds, getActivityDefinition } = useRaidHubManifest()
-
-    return (
-        <ul className="space-y-1">
-            {listedRaidIds
-                .toSorted((a, b) => b - a)
-                .map(raidId => {
-                    const raidDef = getActivityDefinition(raidId)
-                    if (!raidDef) return null
-
-                    return (
-                        <div key={raidId}>
-                            <h3 className="mx-4 inline font-bold">{raidDef.name}</h3>
-                            <Link
-                                href={`/leaderboards/individual/${raidDef.path}/freshClears`}
-                                className="text-raidhub text-lg hover:underline">
-                                Full
-                            </Link>
-                            <span className="text-secondary"> • </span>
-                            <Link
-                                href={`/leaderboards/individual/${raidDef.path}/clears`}
-                                className="text-raidhub text-lg hover:underline">
-                                Any
-                            </Link>
-                        </div>
-                    )
-                })}
-        </ul>
-    )
-}
-
-function SherpaLinks() {
-    const { listedRaidIds, getActivityDefinition } = useRaidHubManifest()
-
-    return (
-        <ul className="space-y-1">
-            {listedRaidIds
-                .toSorted((a, b) => b - a)
-                .map(raidId => {
-                    const raidDef = getActivityDefinition(raidId)
-                    if (!raidDef) return null
-
-                    return (
-                        <li key={raidId}>
-                            <Link
-                                href={`/leaderboards/individual/${raidDef.path}/sherpas`}
-                                className="text-raidhub text-lg hover:underline">
-                                {raidDef.name}
-                            </Link>
-                        </li>
-                    )
-                })}
-        </ul>
-    )
-}
-
-function VersionFirstLinks() {
-    const { listedRaidIds, resprisedRaidIds, getVersionsForActivity, getActivityDefinition } =
-        useRaidHubManifest()
-
-    return (
-        <ul className="space-y-1">
-            {listedRaidIds
-                .toSorted((a, b) => b - a)
-                .map(raidId => {
-                    const raidDef = getActivityDefinition(raidId)
-                    if (!raidDef) return null
-
-                    const isReprised = resprisedRaidIds.includes(raidId)
-                    const miscBoards = getVersionsForActivity(raidId).filter(
-                        v =>
-                            v.id !== 32 &&
-                            v.id !== 2 &&
-                            ((v.id == 1 ? raidId >= 15 : !isReprised) ||
-                                (isReprised && !v.isChallengeMode))
-                    )
-
-                    return (
-                        <div key={raidId}>
-                            <h3 className="mx-4 inline font-bold">{raidDef.name}</h3>
-                            {miscBoards.map((version, idx, arr) => (
-                                <Fragment key={version.id}>
-                                    <Link
-                                        href={`/leaderboards/team/${raidDef.path}/first/${version.path}`}
-                                        className="text-raidhub text-lg hover:underline">
-                                        {version.name.replace("Standard", "Normal Contest")}
-                                    </Link>
-
-                                    {idx < arr.length - 1 && (
-                                        <span className="text-secondary"> • </span>
-                                    )}
-                                </Fragment>
-                            ))}
-                        </div>
-                    )
-                })}
-        </ul>
-    )
-}
-
-function PantheonModeLinks({
+function PantheonCard({
+    activityId,
     versions,
-    keyPrefix
+    includeCommunityRace = false
 }: {
+    activityId: number | null
     versions: readonly number[]
-    keyPrefix: string
+    includeCommunityRace?: boolean
 }) {
-    const { getVersionString, getUrlPathForVersion } = useRaidHubManifest()
+    const { getActivityDefinition, getVersionString, getUrlPathForVersion } = useRaidHubManifest()
+    const [expanded, setExpanded] = useState(false)
+    const title =
+        (activityId != null ? getActivityDefinition(activityId)?.name : null) ?? "The Pantheon"
+    const releaseDate =
+        activityId != null ? getActivityDefinition(activityId)?.releaseDate : null
 
-    if (!versions.length) return null
+    const versionGroups = useMemo(
+        () =>
+            versions
+                .toSorted((a, b) => b - a)
+                .map(version => {
+                    const path = getUrlPathForVersion(version)
+                    if (!path) return null
+
+                    return {
+                        title: getVersionString(version),
+                        links: [
+                            ...(includeCommunityRace && path === PANTHEON_COMMUNITY_RACE_VERSION_PATH
+                                ? [PANTHEON_COMMUNITY_RACE_LINK]
+                                : []),
+                            {
+                                href: `/leaderboards/team/pantheon/first/${path}`,
+                                label: "First Completions"
+                            },
+                            {
+                                href: `/leaderboards/individual/pantheon/${path}/freshClears`,
+                                label: "Full Clears"
+                            }
+                        ]
+                    }
+                })
+                .filter((group): group is LinkSection => group != null),
+        [versions, getVersionString, getUrlPathForVersion, includeCommunityRace]
+    )
 
     return (
-        <>
-            <h3 className="mb-2 text-lg font-bold">First Completions</h3>
-            <ul>
-                {versions.map(version => (
-                    <li key={`${keyPrefix}-first-${version}`}>
-                        <Link
-                            href={`/leaderboards/team/pantheon/first/${getUrlPathForVersion(version)}`}
-                            className="text-raidhub text-lg hover:underline">
-                            {getVersionString(version)}
-                        </Link>
-                    </li>
+        <Card className={cardClass}>
+            <SplashHeader
+                title={title}
+                activityId={activityId}
+                releaseDate={releaseDate}
+                expanded={expanded}
+                onToggle={() => setExpanded(e => !e)}
+            />
+            <CardContent
+                className={cn(
+                    contentClass,
+                    "flex flex-1 flex-col divide-y-0",
+                    expanded
+                        ? "max-md:max-h-[2000px] max-md:opacity-100"
+                        : "max-md:h-0 max-md:max-h-0 max-md:opacity-0"
+                )}>
+                {versionGroups.map(group => (
+                    <SplitLinkSection key={group.title} {...group} />
                 ))}
-            </ul>
-            <h3 className="mt-4 mb-2 text-lg font-bold">Full Clears</h3>
-            <ul>
-                {versions.map(version => (
-                    <li key={`${keyPrefix}-clears-${version}`}>
-                        <Link
-                            href={`/leaderboards/individual/pantheon/${getUrlPathForVersion(
-                                version
-                            )}/freshClears`}
-                            className="text-raidhub text-lg hover:underline">
-                            {getVersionString(version)}
-                        </Link>
-                    </li>
-                ))}
-            </ul>
-        </>
+            </CardContent>
+        </Card>
     )
 }
 
-function PantheonLinks() {
-    const { activePantheonVersions, pantheonSunsetVersions } = useRaidHubManifest()
+function buildRaidSections(
+    raid: RaidHubActivityDefinition,
+    resprisedRaidIds: readonly number[],
+    getVersionsForActivity: (
+        activityId: number
+    ) => readonly { id: number; path: string; name: string; isChallengeMode: boolean }[]
+): LinkSection[] {
+    const path = raid.path
+    const team: LinkItem[] = [
+        { href: `/leaderboards/team/${path}/worldfirst`, label: "World First", accent: "gold" }
+    ]
 
-    return (
-        <div>
-            <PantheonModeLinks versions={activePantheonVersions} keyPrefix="pantheon-active" />
-            {pantheonSunsetVersions.length > 0 && (
-                <div className="mt-6">
-                    <h3 className="text-secondary mb-3 text-sm font-semibold tracking-wide uppercase">
-                        Historical Modes
-                    </h3>
-                    <PantheonModeLinks
-                        versions={pantheonSunsetVersions}
-                        keyPrefix="pantheon-historical"
-                    />
-                </div>
-            )}
-        </div>
+    const speedrun: LinkItem[] = []
+    const srcVar = SpeedrunVariables[path]?.variable
+    if (srcVar) {
+        for (const [type, data] of Object.entries(srcVar.values)) {
+            speedrun.push({
+                href: `/leaderboards/team/${path}/speedrun/${type}`,
+                label: data.displayName
+            })
+        }
+    } else {
+        speedrun.push({
+            href: `/leaderboards/team/${path}/speedrun/any`,
+            label: "Any %"
+        })
+    }
+
+    const isReprised = resprisedRaidIds.includes(raid.id)
+    const miscBoards = getVersionsForActivity(raid.id).filter(
+        v =>
+            v.id !== 32 &&
+            v.id !== 2 &&
+            ((v.id == 1 ? raid.id >= 15 : !isReprised) || (isReprised && !v.isChallengeMode))
     )
+
+    for (const version of miscBoards) {
+        team.push({
+            href: `/leaderboards/team/${path}/first/${version.path}`,
+            label: `First ${version.name.replace("Standard", "Normal Contest")}`
+        })
+    }
+
+    const individual: LinkItem[] = [
+        { href: `/leaderboards/individual/${path}/freshClears`, label: "Full Clears" },
+        { href: `/leaderboards/individual/${path}/clears`, label: "Any Clears" },
+        { href: `/leaderboards/individual/${path}/sherpas`, label: "Sherpas" }
+    ]
+
+    return [
+        { title: "Team", links: team },
+        { title: "Speedrun", links: speedrun },
+        { title: "Individual", links: individual }
+    ]
 }

--- a/src/components/home/HomeBuckets.tsx
+++ b/src/components/home/HomeBuckets.tsx
@@ -4,6 +4,7 @@ import { ChevronRight } from "lucide-react"
 import Link from "next/link"
 import { useMemo, useState } from "react"
 import { useRaidHubManifest } from "~/components/providers/RaidHubManifestManager"
+import { PANTHEON_COMMUNITY_RACE_VERSION_ID } from "~/lib/manifest/pantheon"
 import { SpeedrunVariables } from "~/lib/speedrun/speedrun-com-mappings"
 import { cn } from "~/lib/tw"
 import type { RaidHubActivityDefinition } from "~/services/raidhub/types"
@@ -51,7 +52,7 @@ export const Buckets = () => {
     )
 
     return (
-        <div className="grid items-stretch gap-3 sm:gap-4 [grid-template-columns:repeat(auto-fill,minmax(min(100%,22rem),1fr))]">
+        <div className="grid [grid-template-columns:repeat(auto-fill,minmax(min(100%,22rem),1fr))] items-stretch gap-3 sm:gap-4">
             {raidsBeforeEpic.map(raid => (
                 <RaidCard key={raid.id} raid={raid} />
             ))}
@@ -204,8 +205,6 @@ function RaidCard({ raid }: { raid: RaidHubActivityDefinition }) {
     )
 }
 
-const PANTHEON_COMMUNITY_RACE_VERSION_PATH = "insurrection-revolutionary"
-
 const PANTHEON_COMMUNITY_RACE_LINK: LinkItem = {
     href: "/leaderboards/team/custom/pantheon-community-race",
     label: "Community Race",
@@ -225,8 +224,7 @@ function PantheonCard({
     const [expanded, setExpanded] = useState(false)
     const title =
         (activityId != null ? getActivityDefinition(activityId)?.name : null) ?? "The Pantheon"
-    const releaseDate =
-        activityId != null ? getActivityDefinition(activityId)?.releaseDate : null
+    const releaseDate = activityId != null ? getActivityDefinition(activityId)?.releaseDate : null
 
     const versionGroups = useMemo(
         () =>
@@ -239,7 +237,8 @@ function PantheonCard({
                     return {
                         title: getVersionString(version),
                         links: [
-                            ...(includeCommunityRace && path === PANTHEON_COMMUNITY_RACE_VERSION_PATH
+                            ...(includeCommunityRace &&
+                            version === PANTHEON_COMMUNITY_RACE_VERSION_ID
                                 ? [PANTHEON_COMMUNITY_RACE_LINK]
                                 : []),
                             {

--- a/src/components/home/HomeLogo.tsx
+++ b/src/components/home/HomeLogo.tsx
@@ -4,19 +4,17 @@ import Image from "next/image"
 
 export const HomeLogo = () => {
     return (
-        <div className="flex h-24 items-center justify-center lg:h-32 2xl:h-40">
+        <div className="relative flex h-16 items-center justify-center">
             <Image
                 src="/logo.png"
                 alt=""
-                className="absolute left-1/2 size-24 -translate-x-1/2 opacity-10 lg:size-32 2xl:size-40"
-                width={70}
-                height={70}
+                className="absolute size-16 opacity-10"
+                width={64}
+                height={64}
             />
-            <h1 className="font-sans text-6xl font-extrabold tracking-widest whitespace-nowrap text-white uppercase md:text-2xl lg:text-4xl xl:text-6xl">
+            <h1 className="relative font-sans text-4xl font-extrabold tracking-widest whitespace-nowrap text-white uppercase sm:text-5xl">
                 Raid
-                <span className="text-raidhub text-shadow-raidhub drop-shadow text-shadow-[0_0_3rem]">
-                    Hub
-                </span>
+                <span className="text-raidhub">Hub</span>
             </h1>
         </div>
     )

--- a/src/components/home/HomeQuickLinks.tsx
+++ b/src/components/home/HomeQuickLinks.tsx
@@ -8,71 +8,79 @@ import {
     ChartSpline,
     HeartHandshake,
     Hourglass,
-    Users
+    Users,
+    type LucideIcon
 } from "lucide-react"
 import Link from "next/link"
 import D2CheckpointFlag from "~/components/icons/D2CP"
+import { cn } from "~/lib/tw"
 
-const navLinks = [
+const navLinks: { title: string; href: string; icon: LucideIcon }[] = [
+    { title: "Clans", href: "/clans", icon: Users },
     {
-        title: "Clan Leaderboards",
-        href: "/clans",
-        icon: Users
-    },
-    {
-        title: "World First Rating Rankings",
+        title: "WF Rankings",
         href: "/leaderboards/individual/global/world-first-rankings",
         icon: ChartNoAxesColumnDecreasing
     },
+    { title: "Weapon Meta", href: "/analytics/weapon-meta", icon: ChartNoAxesCombined },
+    { title: "Population", href: "/analytics/player-population", icon: ChartSpline },
+    { title: "Checkpoints", href: "/checkpoints", icon: D2CheckpointFlag },
     {
-        title: "Weapon Meta",
-        href: "/analytics/weapon-meta",
-        icon: ChartNoAxesCombined
-    },
-    {
-        title: "Player Population",
-        href: "/analytics/player-population",
-        icon: ChartSpline
-    },
-    {
-        title: "Checkpoints",
-        href: "/checkpoints",
-        icon: D2CheckpointFlag
-    },
-    {
-        title: "Full Clears Leaderboard",
+        title: "Full Clears",
         href: "/leaderboards/individual/global/full-clears",
         icon: ChartBarBig
     },
     {
-        title: "Clears Leaderboard",
+        title: "Clears",
         href: "/leaderboards/individual/global/clears",
         icon: ChartBarDecreasing
     },
     {
-        title: "Sherpa Leaderboard",
+        title: "Sherpas",
         href: "/leaderboards/individual/global/sherpas",
         icon: HeartHandshake
     },
     {
-        title: "In Raid Time Leaderboard",
+        title: "In Raid Time",
         href: "/leaderboards/individual/global/in-raid-time",
         icon: Hourglass
     }
 ]
 
+const mobileTileClass =
+    "border-border/50 bg-card/40 text-muted-foreground hover:border-raidhub/30 hover:text-raidhub flex flex-col items-center justify-center gap-1.5 rounded-lg border px-2 py-3 text-center text-xs transition-colors"
+
+const desktopLinkClass =
+    "text-muted-foreground hover:text-raidhub inline-flex items-center gap-1.5 text-sm transition-colors"
+
 export const HomeQuickLinks = () => {
     return (
-        <div className="6xl:max-w-520 mx-auto grid max-w-240 grid-cols-1 justify-center md:grid-cols-[repeat(auto-fit,minmax(10rem,12rem))] md:gap-3 xl:max-w-300">
-            {navLinks.map((link, idx) => (
-                <Link
-                    key={idx}
-                    href={link.href}
-                    className="border-muted bg-background/60 text-muted-foreground hover:bg-raidhub/50 flex items-center gap-2 border p-2 text-center transition-colors duration-150 md:flex-col md:justify-center">
-                    <link.icon className="text-primary size-8" />
-                    <div className="text-sm">{link.title}</div>
-                </Link>
-            ))}
-        </div>
+        <nav aria-label="Quick access">
+            <ul className="grid grid-cols-3 gap-2 md:grid-cols-4 min-[960px]:grid-cols-5 lg:hidden">
+                {navLinks.map(link => (
+                    <li key={link.href}>
+                        <Link href={link.href} className={mobileTileClass}>
+                            <link.icon className="size-5 shrink-0" />
+                            <span>{link.title}</span>
+                        </Link>
+                    </li>
+                ))}
+            </ul>
+
+            <ul
+                className={cn(
+                    "border-border/40 hidden flex-wrap justify-center gap-x-5 gap-y-2 border-y py-3",
+                    "lg:flex"
+                )}>
+                {navLinks.map(link => (
+                    <li key={link.href}>
+                        <Link href={link.href} className={desktopLinkClass}>
+                            <link.icon className="size-4 shrink-0" />
+                            {link.title}
+                        </Link>
+                    </li>
+                ))}
+            </ul>
+        </nav>
     )
 }

--- a/src/components/home/HomeQuickLinks.tsx
+++ b/src/components/home/HomeQuickLinks.tsx
@@ -56,7 +56,7 @@ const desktopLinkClass =
 export const HomeQuickLinks = () => {
     return (
         <nav aria-label="Quick access">
-            <ul className="grid grid-cols-3 gap-2 md:grid-cols-4 min-[960px]:grid-cols-5 lg:hidden">
+            <ul className="grid grid-cols-3 gap-2 min-[960px]:grid-cols-5 md:grid-cols-4 lg:hidden">
                 {navLinks.map(link => (
                     <li key={link.href}>
                         <Link href={link.href} className={mobileTileClass}>

--- a/src/components/home/HomeSearchButton.tsx
+++ b/src/components/home/HomeSearchButton.tsx
@@ -7,12 +7,12 @@ export const HomeSearchButton = () => {
     const [, setOpen] = useSearchContext()
     return (
         <div
-            className="text-muted-foreground hover:border-raidhub/30 bg-background/80 mx-auto flex h-12 max-w-120 cursor-pointer items-center gap-2 rounded-md border-1 p-2 text-sm"
+            className="text-muted-foreground border-border/60 bg-background/40 hover:border-raidhub/40 mx-auto flex h-10 w-full max-w-md cursor-pointer items-center gap-2 rounded-md border px-3 text-sm transition-colors"
             onClick={e => {
                 e.preventDefault()
                 setOpen(true)
             }}>
-            <Search className="size-6" />
+            <Search className="size-4 shrink-0" />
             Search for a Guardian
         </div>
     )

--- a/src/components/providers/RaidHubManifestManager.tsx
+++ b/src/components/providers/RaidHubManifestManager.tsx
@@ -39,6 +39,7 @@ type ManifestContextData = RaidHubManifestResponse & {
     getActivityDefinition(activityId: number): RaidHubActivityDefinition | null
     isChallengeMode(versionId: number): boolean
     getImageVariantsForActivity(activityId: number | string): readonly ImageContentData[]
+    getImageVariantsForVersion(versionId: number | string): readonly ImageContentData[]
 }
 
 const ManifestContext = createContext<ManifestContextData | undefined>(undefined)
@@ -117,6 +118,10 @@ export function RaidHubManifestManager(props: {
             },
             getImageVariantsForActivity(activityId) {
                 const variants = data.splashUrls[activityId]
+                return variants ?? []
+            },
+            getImageVariantsForVersion(versionId) {
+                const variants = data.versionSplashUrls[versionId]
                 return variants ?? []
             }
         }

--- a/src/lib/manifest/pantheon.ts
+++ b/src/lib/manifest/pantheon.ts
@@ -1,5 +1,7 @@
 import type { RaidHubManifestResponse, RaidHubVersionDefinition } from "~/services/raidhub/types"
 
+export const PANTHEON_COMMUNITY_RACE_VERSION_ID = 134
+
 export const findPantheonVersionByPath = (
     manifest: RaidHubManifestResponse,
     versionPath: string

--- a/src/lib/speedrun/speedrun-com-mappings.ts
+++ b/src/lib/speedrun/speedrun-com-mappings.ts
@@ -2,6 +2,7 @@ export type RTABoardCategory =
     | "standard"
     | "any-percent"
     | "trio"
+    | "quad"
     | "prestige"
     | "trio-all-encounters"
 
@@ -137,7 +138,15 @@ export const SpeedrunVariables: Record<
         }
     },
     salvationsedge: {
-        categoryId: "9kvzop8d"
+        categoryId: "9kvzop8d",
+        variable: {
+            variableId: "yn26d2gl",
+            values: {
+                "any-percent": { id: "1w4o3xmq", displayName: "Any %" },
+                trio: { id: "qoxod65q", displayName: "Trio" },
+                quad: { id: "qj7vmxeq", displayName: "Quad" }
+            }
+        }
     },
     desertPerpetual: {
         categoryId: "not-implemented"

--- a/src/services/raidhub/openapi.d.ts
+++ b/src/services/raidhub/openapi.d.ts
@@ -1289,6 +1289,91 @@ export interface paths {
       };
     };
   };
+  "/leaderboard/team/custom/pantheon-community-race": {
+    /**
+     * /leaderboard/team/custom/pantheon-community-race
+     * @description Ranking of teams that completed the 5-feat Insurrection Prime Revolutionary pantheon version during the community-hosted raid race window (first 24 hours from 2026-06-13 17:00 UTC).
+     */
+    get: {
+      parameters: {
+        query?: {
+          count?: number;
+          search?: string;
+          page?: number;
+        };
+      };
+      responses: {
+        /** @description Success */
+        200: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: true;
+              readonly response: components["schemas"]["LeaderboardTeamCustomPantheonCommunityRaceResponse"];
+            };
+          };
+        };
+        /** @description Bad request */
+        400: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "QueryValidationError";
+              readonly error: components["schemas"]["QueryValidationError"];
+            };
+          };
+        };
+        /** @description Unauthorized */
+        401: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "ApiKeyError";
+              readonly error: components["schemas"]["ApiKeyError"];
+            };
+          };
+        };
+        /** @description PlayerNotOnLeaderboardError */
+        404: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "PlayerNotOnLeaderboardError";
+              readonly error: components["schemas"]["PlayerNotOnLeaderboardError"];
+            };
+          };
+        };
+        /** @description Internal Server Error */
+        500: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: false;
+              /** @enum {string} */
+              readonly code: "InternalServerError";
+              readonly error: components["schemas"]["InternalServerError"];
+            };
+          };
+        };
+      };
+    };
+  };
   "/leaderboard/clan": {
     /**
      * /leaderboard/clan
@@ -2742,7 +2827,7 @@ export interface components {
       readonly issues: readonly components["schemas"]["ZodIssue"][];
     };
     /**
-     * @description MotT difficulty tier derived from PGCR skull hashes. Adventure uses fixed skulls; Custom has selected feats; Standard is Custom with no feats.
+     * @description MotT difficulty tier derived at read time from instance skull_hashes and activity_feat_definition. Adventure uses fixed skulls; Custom has selected feats; Standard is Custom with no feats.
      * @enum {string}
      */
     readonly DifficultyTier: "adventure" | "standard" | "custom";
@@ -3370,6 +3455,10 @@ export interface components {
       readonly splashUrls: {
         [key: string]: readonly components["schemas"]["ImageContentData"][];
       };
+      /** @description The mapping of each RaidHub versionId to its splash image URLs */
+      readonly versionSplashUrls: {
+        [key: string]: readonly components["schemas"]["ImageContentData"][];
+      };
     };
     readonly StatusResponse: {
       readonly AtlasPGCR: components["schemas"]["AtlasStatus"];
@@ -3544,6 +3633,23 @@ export interface components {
       readonly version: string;
     };
     readonly LeaderboardTeamContestResponse: OneOf<[{
+      /** @enum {string} */
+      readonly type: "team";
+      /** @enum {string} */
+      readonly format: "duration" | "numerical";
+      readonly page: number;
+      readonly count: number;
+      readonly entries: readonly components["schemas"]["TeamLeaderboardEntry"][];
+    }, {
+      /** @enum {string} */
+      readonly type: "individual";
+      /** @enum {string} */
+      readonly format: "duration" | "numerical";
+      readonly page: number;
+      readonly count: number;
+      readonly entries: readonly components["schemas"]["IndividualLeaderboardEntry"][];
+    }]>;
+    readonly LeaderboardTeamCustomPantheonCommunityRaceResponse: OneOf<[{
       /** @enum {string} */
       readonly type: "team";
       /** @enum {string} */

--- a/src/services/raidhub/types.ts
+++ b/src/services/raidhub/types.ts
@@ -64,11 +64,16 @@ export type RaidHubLeaderboardURL = RaidHubGetPath &
         | "/leaderboard/individual/pantheon/{version}/{category}"
         | "/leaderboard/individual/raid/{raid}/{category}"
         | "/leaderboard/team/contest/{raid}"
+        | "/leaderboard/team/custom/pantheon-community-race"
         | "/leaderboard/team/first/{activity}/{version}"
     )
 
 export type PathParamsForLeaderboardURL<T extends RaidHubLeaderboardURL> =
-    paths[T]["get"]["parameters"]["path"]
+    T extends "/leaderboard/team/custom/pantheon-community-race"
+        ? null
+        : paths[T]["get"]["parameters"] extends { path: infer P }
+          ? P
+          : never
 export type ResponseForLeaderboardURL<T extends RaidHubLeaderboardURL> =
     paths[T]["get"]["responses"][200]["content"]["application/json"]
 


### PR DESCRIPTION
## Summary
- Replaces category-based home buckets with per-activity cards using splash headers, manifest-driven names/release dates, and split Team/Speedrun/Individual (raid) or version-grouped (pantheon) link sections
- Adds responsive quick-link tile grid below `lg`, with 3/4/5 column breakpoints on smaller viewports
- Adds pantheon community race leaderboard page and home link (gold accent, Insurrection Prime group, first in version order) wired to `/leaderboard/team/custom/pantheon-community-race`
- Fixes activity splash images using `object-cover` on `fill` to prevent stretched leaderboard headers

## Test plan
- [ ] Verify homepage cards layout at mobile, tablet, and wide desktop widths
- [ ] Confirm active pantheon card shows Community Race (gold) under Insurrection Prime Revolutionary before other versions
- [ ] Open `/leaderboards/team/custom/pantheon-community-race` and confirm leaderboard loads (requires [Raid-Hub/API#137](https://github.com/Raid-Hub/API/pull/137) deployed)
- [ ] Spot-check other team leaderboard splashes are cropped, not stretched


Made with [Cursor](https://cursor.com)