### PR TITLE
Add admin-only blacklist action to PGCR menu

### DIFF
--- a/src/components/pgcr/pgcr-menu.tsx
+++ b/src/components/pgcr/pgcr-menu.tsx
@@ -1,9 +1,11 @@
 "use client"
 
-import { AlertTriangle, MoreVertical, Share2 } from "lucide-react"
+import { AlertTriangle, Ban, MoreVertical, Share2 } from "lucide-react"
 import { useState } from "react"
 import { toast } from "sonner"
 import { useSession } from "~/hooks/app/useSession"
+import { usePGCRContext } from "~/hooks/pgcr/ClientStateManager"
+import { useRaidHubBlacklist } from "~/services/raidhub/useRaidHubBlacklist"
 import { Button } from "~/shad/button"
 import {
     DropdownMenu,
@@ -16,8 +18,24 @@ import { ReportModal } from "./pgcr-report-modal"
 
 export const PGCRMenu = () => {
     const session = useSession()
+    const { data } = usePGCRContext()
     const [isMenuOpen, setIsMenuOpen] = useState(false)
     const [isReportModalOpen, setIsReportModalOpen] = useState(false)
+    const [isBlacklisted, setIsBlacklisted] = useState(data.isBlacklisted)
+
+    const isAdmin = session.data?.user.role === "ADMIN"
+
+    const blacklistMutation = useRaidHubBlacklist(data.instanceId, {
+        onSuccess: blacklisted => {
+            setIsBlacklisted(blacklisted)
+            toast.success(`Instance ${data.instanceId} has been blacklisted`)
+        },
+        onError: error => {
+            toast.error(`Failed to blacklist instance ${data.instanceId}`, {
+                description: error.message
+            })
+        }
+    })
 
     return (
         <DropdownMenu open={isMenuOpen} onOpenChange={setIsMenuOpen}>
@@ -27,14 +45,6 @@ export const PGCRMenu = () => {
                 </Button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="w-48">
-                {/* <DropdownMenuItem className="cursor-pointer">
-                <Star className="mr-2 h-4 w-4" />
-                <span>Favorite</span>
-            </DropdownMenuItem>
-            <DropdownMenuItem className="cursor-pointer">
-                <Pin className="mr-2 h-4 w-4" />
-                <span>Pin</span>
-            </DropdownMenuItem> */}
                 <DropdownMenuItem
                     className="cursor-pointer"
                     onClick={async () => {
@@ -57,6 +67,24 @@ export const PGCRMenu = () => {
                             <AlertTriangle className="mr-2 h-4 w-4" />
                             <span>Report</span>
                         </DropdownMenuItem>
+
+                        {isAdmin && (
+                            <DropdownMenuItem
+                                className="cursor-pointer text-red-500"
+                                disabled={isBlacklisted || blacklistMutation.isLoading}
+                                onSelect={event => {
+                                    event.preventDefault()
+                                    blacklistMutation.mutate({
+                                        removeBlacklist: false,
+                                        reason: "Blacklisted by an administrator from the PGCR page"
+                                    })
+                                }}>
+                                <Ban className="mr-2 h-4 w-4" />
+                                <span>
+                                    {isBlacklisted ? "Blacklisted" : "Blacklist Instance"}
+                                </span>
+                            </DropdownMenuItem>
+                        )}
                     </>
                 )}
             </DropdownMenuContent>

--- a/src/components/pgcr/pgcr-menu.tsx
+++ b/src/components/pgcr/pgcr-menu.tsx
@@ -80,9 +80,7 @@ export const PGCRMenu = () => {
                                     })
                                 }}>
                                 <Ban className="mr-2 h-4 w-4" />
-                                <span>
-                                    {isBlacklisted ? "Blacklisted" : "Blacklist Instance"}
-                                </span>
+                                <span>{isBlacklisted ? "Blacklisted" : "Blacklist Instance"}</span>
                             </DropdownMenuItem>
                         )}
                     </>


### PR DESCRIPTION
## Summary
- Add an admin-only "Blacklist Instance" item to the PGCR page menu, directly beneath the Report item.
- One click immediately blacklists the instance via the existing `PUT /admin/reporting/blacklist/{instanceId}` endpoint (reused through the `useRaidHubBlacklist` hook).
- The item only renders when the signed-in user has the `ADMIN` role, and reflects/disables when the instance is already blacklisted.

## Test plan
- [ ] As a non-admin authenticated user, confirm only Share + Report appear in the PGCR menu.
- [ ] As an admin, confirm a "Blacklist Instance" item appears under Report.
- [ ] Click it and confirm a success toast appears and the item becomes disabled/"Blacklisted".
- [ ] Reload the PGCR and confirm the blacklist warning shows in the header.

Made with [Cursor](https://cursor.com)