### PR TITLE
Trim pantheon season suffix from PGCR titles

### DIFF
--- a/src/app/pgcr/[instanceId]/server.ts
+++ b/src/app/pgcr/[instanceId]/server.ts
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation"
+import { getPgcrShortActivityName } from "~/lib/pgcr/formatting"
 import { Tag } from "~/models/tag"
 import { RaidHubError } from "~/services/raidhub/RaidHubError"
 import { getRaidHubApi } from "~/services/raidhub/common"
@@ -37,7 +38,9 @@ export const getMetaData = (activity: RaidHubInstanceExtended) => {
 
     const versionPrefix = activity.versionId === 1 ? null : activity.metadata.versionName
 
-    const activityName = activity.metadata.activityName
+    const activityName = activity.metadata.isRaid
+        ? activity.metadata.activityName
+        : getPgcrShortActivityName(activity.metadata.activityName)
 
     const resultSuffix = activity.completed
         ? activity.fresh === false
@@ -59,7 +62,7 @@ export const getMetaData = (activity: RaidHubInstanceExtended) => {
         timeZoneName: "short"
     })
 
-    const idTitle = [activity.metadata.activityName, activity.instanceId].filter(Boolean).join(" ")
+    const idTitle = [activityName, activity.instanceId].filter(Boolean).join(" ")
 
     const ogTitle = [
         lowmanPrefix,

--- a/src/components/pgcr/pgcr-header.tsx
+++ b/src/components/pgcr/pgcr-header.tsx
@@ -1,4 +1,5 @@
 import { CheckCircle, Clock, MapPin, TriangleAlert, Users, XCircle } from "lucide-react"
+import { getPgcrDisplayTitle } from "~/lib/pgcr/formatting"
 import { cn } from "~/lib/tw"
 import { type RaidHubInstanceExtended } from "~/services/raidhub/types"
 import { Badge } from "~/shad/badge"
@@ -40,9 +41,7 @@ export const PGCRHeader = ({ data }: PGCRHeaderProps) => {
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
                     <h1 className="text-2xl font-bold tracking-tight text-white md:text-4xl">
-                        {data.metadata.isRaid
-                            ? data.metadata.activityName
-                            : `${data.metadata.activityName}: ${data.metadata.versionName}`}
+                        {getPgcrDisplayTitle(data.metadata)}
                     </h1>
 
                     {/* Cleared status badge */}

--- a/src/lib/pgcr/formatting.ts
+++ b/src/lib/pgcr/formatting.ts
@@ -1,0 +1,19 @@
+type PgcrTitleMetadata = {
+    isRaid: boolean
+    activityName: string
+    versionName: string
+}
+
+/** Pantheon activity names include a season suffix (e.g. "Pantheon: Monument of Triumph"). */
+export const getPgcrShortActivityName = (activityName: string) => {
+    const colonIndex = activityName.indexOf(":")
+    return colonIndex === -1 ? activityName : activityName.slice(0, colonIndex).trim()
+}
+
+export const getPgcrDisplayTitle = ({ isRaid, activityName, versionName }: PgcrTitleMetadata) => {
+    if (isRaid) {
+        return activityName
+    }
+
+    return `${getPgcrShortActivityName(activityName)}: ${versionName}`
+}

--- a/src/lib/pgcr/server.ts
+++ b/src/lib/pgcr/server.ts
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation"
+import { getPgcrShortActivityName } from "~/lib/pgcr/formatting"
 import { Tag } from "~/models/tag"
 import { RaidHubError } from "~/services/raidhub/RaidHubError"
 import { getRaidHubApi } from "~/services/raidhub/common"
@@ -37,7 +38,9 @@ export const getMetaData = (activity: RaidHubInstanceExtended) => {
 
     const versionPrefix = activity.versionId === 1 ? null : activity.metadata.versionName
 
-    const activityName = activity.metadata.activityName
+    const activityName = activity.metadata.isRaid
+        ? activity.metadata.activityName
+        : getPgcrShortActivityName(activity.metadata.activityName)
 
     const resultSuffix = activity.completed
         ? activity.fresh === false
@@ -59,7 +62,7 @@ export const getMetaData = (activity: RaidHubInstanceExtended) => {
         timeZoneName: "short"
     })
 
-    const idTitle = [activity.metadata.activityName, activity.instanceId].filter(Boolean).join(" ")
+    const idTitle = [activityName, activity.instanceId].filter(Boolean).join(" ")
 
     const ogTitle = [
         lowmanPrefix,


### PR DESCRIPTION
## Summary
- Drop the pantheon season label (e.g. "Monument of Triumph") from PGCR page titles by trimming everything after the first colon in the activity name
- PGCR headers and metadata now display titles like **Pantheon: Morgeth Surpassing** instead of **Pantheon: Monument of Triumph: Morgeth Surpassing**

## Test plan
- [ ] Open a Monument of Triumph pantheon PGCR and confirm the header reads `Pantheon: <version name>`
- [ ] Open an Into the Light pantheon PGCR and confirm the header reads `Pantheon: <version name>`
- [ ] Open a raid PGCR and confirm the title is unchanged (activity name only)
- [ ] Check PGCR opengraph metadata/title for pantheon instances


Made with [Cursor](https://cursor.com)