### PR TITLE
fix: fixed overlap between LeaderboardEntryComponent and LeaderboardSearch.Result

### DIFF
--- a/src/app/leaderboards/LeaderboardEntryComponent.tsx
+++ b/src/app/leaderboards/LeaderboardEntryComponent.tsx
@@ -76,7 +76,7 @@ export const LeaderboardEntryComponent = ({
             )}
 
             {/* Left side */}
-            <div className="pointer-events-none relative z-10 flex-1">
+            <div className="pointer-events-none flex-1">
                 {/* Players */}
                 <div className="flex gap-4 p-2">
                     <div className="flex aspect-square min-w-5 flex-col justify-center text-lg">


### PR DESCRIPTION
This pr fixes an overlapping issue between the Result element of LeaderboardSearch component and the LeaderboardEntryComponent.

The issue:
<img width="1674" height="339" alt="image" src="https://github.com/user-attachments/assets/88ef9ba4-f275-4236-8d25-54b9ad685b37" />
