### PR TITLE
Fix PGCR mobile header clipping and improve admin blacklist flow

### DIFF
--- a/src/components/pgcr/pgcr-blacklist-modal.tsx
+++ b/src/components/pgcr/pgcr-blacklist-modal.tsx
@@ -99,7 +99,9 @@ export const BlacklistModal = ({ open, onOpenChange, onSuccess }: BlacklistModal
                                 type="submit"
                                 variant="destructive"
                                 disabled={blacklistMutation.isLoading || !reason.trim()}>
-                                {blacklistMutation.isLoading ? "Blacklisting..." : "Blacklist Instance"}
+                                {blacklistMutation.isLoading
+                                    ? "Blacklisting..."
+                                    : "Blacklist Instance"}
                             </Button>
                         </DialogFooter>
                     </form>

--- a/src/components/pgcr/pgcr-blacklist-modal.tsx
+++ b/src/components/pgcr/pgcr-blacklist-modal.tsx
@@ -1,0 +1,110 @@
+import { Ban } from "lucide-react"
+import { useForm } from "react-hook-form"
+import { usePGCRContext } from "~/hooks/pgcr/ClientStateManager"
+import { useRaidHubBlacklist } from "~/services/raidhub/useRaidHubBlacklist"
+import { Button } from "~/shad/button"
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle
+} from "~/shad/dialog"
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "~/shad/form"
+import { Textarea } from "~/shad/textarea"
+
+interface BlacklistModalProps {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    onSuccess: (blacklisted: boolean) => void
+}
+
+export const BlacklistModal = ({ open, onOpenChange, onSuccess }: BlacklistModalProps) => {
+    const { data } = usePGCRContext()
+
+    const form = useForm<{ reason: string }>({
+        defaultValues: { reason: "" }
+    })
+
+    const reason = form.watch("reason")
+
+    const blacklistMutation = useRaidHubBlacklist(data.instanceId, {
+        onSuccess: blacklisted => {
+            onSuccess(blacklisted)
+            form.reset()
+            onOpenChange(false)
+        },
+        onError: error => {
+            form.setError("reason", { message: error.message })
+        }
+    })
+
+    const handleSubmit = form.handleSubmit(({ reason }) => {
+        blacklistMutation.mutate({
+            removeBlacklist: false,
+            reason
+        })
+    })
+
+    return (
+        <Dialog
+            open={open}
+            onOpenChange={nextOpen => {
+                if (!nextOpen) {
+                    form.reset()
+                }
+                onOpenChange(nextOpen)
+            }}>
+            <DialogContent className="sm:max-w-md">
+                <Form {...form}>
+                    <form onSubmit={handleSubmit} className="space-y-4">
+                        <DialogHeader>
+                            <DialogTitle className="flex items-center gap-2">
+                                <Ban className="h-5 w-5 text-red-500" />
+                                Blacklist Instance
+                            </DialogTitle>
+                            <DialogDescription>
+                                Add this instance to the blacklist. It will be removed from
+                                leaderboards and will not appear as a tag on participant profiles.
+                            </DialogDescription>
+                        </DialogHeader>
+                        <FormField
+                            control={form.control}
+                            name="reason"
+                            rules={{ required: "A reason is required" }}
+                            render={({ field }) => (
+                                <FormItem>
+                                    <FormLabel>Reason</FormLabel>
+                                    <FormControl>
+                                        <Textarea
+                                            {...field}
+                                            className="h-24 resize-none text-sm"
+                                            placeholder="Enter reason for blacklisting this instance..."
+                                        />
+                                    </FormControl>
+                                    <FormMessage />
+                                </FormItem>
+                            )}
+                        />
+                        <DialogFooter>
+                            <Button
+                                type="button"
+                                variant="outline"
+                                onClick={() => onOpenChange(false)}
+                                disabled={blacklistMutation.isLoading}>
+                                Cancel
+                            </Button>
+                            <Button
+                                type="submit"
+                                variant="destructive"
+                                disabled={blacklistMutation.isLoading || !reason.trim()}>
+                                {blacklistMutation.isLoading ? "Blacklisting..." : "Blacklist Instance"}
+                            </Button>
+                        </DialogFooter>
+                    </form>
+                </Form>
+            </DialogContent>
+        </Dialog>
+    )
+}

--- a/src/components/pgcr/pgcr-header-bg.tsx
+++ b/src/components/pgcr/pgcr-header-bg.tsx
@@ -22,7 +22,7 @@ export const PGCRHeaderBackground = ({
     const backgroundImageUrl = variant?.url ?? FallbackSplash
     return (
         <div
-            className="relative min-h-44 overflow-hidden rounded-t-lg bg-cover bg-center md:h-48"
+            className="relative min-h-44 rounded-t-lg bg-cover bg-center md:min-h-48"
             style={{
                 backgroundImage: `url(${backgroundImageUrl})`
             }}>

--- a/src/components/pgcr/pgcr-header.tsx
+++ b/src/components/pgcr/pgcr-header.tsx
@@ -1,7 +1,9 @@
+"use client"
+
 import { CheckCircle, Clock, MapPin, TriangleAlert, Users, XCircle } from "lucide-react"
+import { usePGCRContext } from "~/hooks/pgcr/ClientStateManager"
 import { getPgcrDisplayTitle } from "~/lib/pgcr/formatting"
 import { cn } from "~/lib/tw"
-import { type RaidHubInstanceExtended } from "~/services/raidhub/types"
 import { Badge } from "~/shad/badge"
 import { CardHeader } from "~/shad/card"
 import { Tooltip, TooltipContent, TooltipTrigger } from "~/shad/tooltip"
@@ -12,15 +14,12 @@ import { PGCRHeaderBackground } from "./pgcr-header-bg"
 import { PGCRMenu } from "./pgcr-menu"
 import { PGCRTags } from "./pgcr-tags"
 
-interface PGCRHeaderProps {
-    data: RaidHubInstanceExtended
-}
-
-export const PGCRHeader = ({ data }: PGCRHeaderProps) => {
+export const PGCRHeader = () => {
+    const { data } = usePGCRContext()
     return (
         <PGCRHeaderBackground activityId={data.activityId} versionId={data.versionId}>
             <div className="absolute inset-0 bg-gradient-to-r from-black/70 via-black/50 to-black/30 backdrop-blur-[2px]" />
-            <CardHeader className="absolute inset-0 flex flex-col gap-2 p-2 md:p-6">
+            <CardHeader className="relative z-10 flex flex-col gap-2 p-2 md:p-6">
                 <div className="inline-flex gap-4">
                     <PGCRDate />
                     {data.isBlacklisted && (

--- a/src/components/pgcr/pgcr-menu.tsx
+++ b/src/components/pgcr/pgcr-menu.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { AlertTriangle, Ban, MoreVertical, Share2 } from "lucide-react"
+import { AlertTriangle, Ban, MoreVertical, Share2, ShieldCheck } from "lucide-react"
 import { useState } from "react"
 import { toast } from "sonner"
 import { useSession } from "~/hooks/app/useSession"
@@ -14,24 +14,25 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger
 } from "~/shad/dropdown-menu"
+import { BlacklistModal } from "./pgcr-blacklist-modal"
 import { ReportModal } from "./pgcr-report-modal"
 
 export const PGCRMenu = () => {
     const session = useSession()
-    const { data } = usePGCRContext()
+    const { data, setIsBlacklisted } = usePGCRContext()
     const [isMenuOpen, setIsMenuOpen] = useState(false)
     const [isReportModalOpen, setIsReportModalOpen] = useState(false)
-    const [isBlacklisted, setIsBlacklisted] = useState(data.isBlacklisted)
+    const [isBlacklistModalOpen, setIsBlacklistModalOpen] = useState(false)
 
     const isAdmin = session.data?.user.role === "ADMIN"
 
-    const blacklistMutation = useRaidHubBlacklist(data.instanceId, {
+    const unblacklistMutation = useRaidHubBlacklist(data.instanceId, {
         onSuccess: blacklisted => {
             setIsBlacklisted(blacklisted)
-            toast.success(`Instance ${data.instanceId} has been blacklisted`)
+            toast.success(`Instance ${data.instanceId} has been removed from the blacklist`)
         },
         onError: error => {
-            toast.error(`Failed to blacklist instance ${data.instanceId}`, {
+            toast.error(`Failed to remove instance ${data.instanceId} from the blacklist`, {
                 description: error.message
             })
         }
@@ -68,21 +69,32 @@ export const PGCRMenu = () => {
                             <span>Report</span>
                         </DropdownMenuItem>
 
-                        {isAdmin && (
-                            <DropdownMenuItem
-                                className="cursor-pointer text-red-500"
-                                disabled={isBlacklisted || blacklistMutation.isLoading}
-                                onSelect={event => {
-                                    event.preventDefault()
-                                    blacklistMutation.mutate({
-                                        removeBlacklist: false,
-                                        reason: "Blacklisted by an administrator from the PGCR page"
-                                    })
-                                }}>
-                                <Ban className="mr-2 h-4 w-4" />
-                                <span>{isBlacklisted ? "Blacklisted" : "Blacklist Instance"}</span>
-                            </DropdownMenuItem>
-                        )}
+                        {isAdmin &&
+                            (data.isBlacklisted ? (
+                                <DropdownMenuItem
+                                    className="cursor-pointer"
+                                    disabled={unblacklistMutation.isLoading}
+                                    onSelect={event => {
+                                        event.preventDefault()
+                                        unblacklistMutation.mutate({
+                                            removeBlacklist: true,
+                                            reason: "Instance cleared from blacklist"
+                                        })
+                                    }}>
+                                    <ShieldCheck className="mr-2 h-4 w-4" />
+                                    <span>Remove from Blacklist</span>
+                                </DropdownMenuItem>
+                            ) : (
+                                <DropdownMenuItem
+                                    className="cursor-pointer text-red-500"
+                                    onClick={() => {
+                                        setIsMenuOpen(false)
+                                        setIsBlacklistModalOpen(true)
+                                    }}>
+                                    <Ban className="mr-2 h-4 w-4" />
+                                    <span>Blacklist Instance</span>
+                                </DropdownMenuItem>
+                            ))}
                     </>
                 )}
             </DropdownMenuContent>
@@ -90,6 +102,14 @@ export const PGCRMenu = () => {
                 reporterProfiles={session.data?.user.profiles.map(p => p.destinyMembershipId) ?? []}
                 open={isReportModalOpen}
                 onOpenChange={setIsReportModalOpen}
+            />
+            <BlacklistModal
+                open={isBlacklistModalOpen}
+                onOpenChange={setIsBlacklistModalOpen}
+                onSuccess={blacklisted => {
+                    setIsBlacklisted(blacklisted)
+                    toast.success(`Instance ${data.instanceId} has been blacklisted`)
+                }}
             />
         </DropdownMenu>
     )

--- a/src/components/pgcr/pgcr-view.tsx
+++ b/src/components/pgcr/pgcr-view.tsx
@@ -70,7 +70,7 @@ export default function PGCR({ data }: PGCRProps) {
             playerStatsMerged={Array.from(playerMergedStats.entries())}>
             <div className="container mx-auto my-auto w-full max-w-5xl">
                 <Card className="w-full gap-0 overflow-hidden border border-zinc-800 bg-zinc-950 py-0 shadow-md md:w-[768px] lg:w-[956px] xl:w-[1096px]">
-                    <PGCRHeader data={data} />
+                    <PGCRHeader />
 
                     <Separator className="bg-zinc-800" />
 

--- a/src/hooks/pgcr/ClientStateManager.tsx
+++ b/src/hooks/pgcr/ClientStateManager.tsx
@@ -99,10 +99,7 @@ export const ClientStateManager = ({
 
     const [isReportModalOpen, setIsReportModalOpen] = useState(false)
     const [isBlacklisted, setIsBlacklisted] = useState(data.isBlacklisted)
-    const instanceData = useMemo(
-        () => ({ ...data, isBlacklisted }),
-        [data, isBlacklisted]
-    )
+    const instanceData = useMemo(() => ({ ...data, isBlacklisted }), [data, isBlacklisted])
 
     const query = useQueryParams<PGCRPageParams>(
         z.object({

--- a/src/hooks/pgcr/ClientStateManager.tsx
+++ b/src/hooks/pgcr/ClientStateManager.tsx
@@ -43,6 +43,7 @@ interface ClientStateManagerProps {
 
 interface PGCRState {
     data: RaidHubInstanceExtended
+    setIsBlacklisted: Dispatch<SetStateAction<boolean>>
     playerStatsMerged: Collection<string, PlayerStats>
     mvp: string | null
     scores: Collection<
@@ -97,6 +98,11 @@ export const ClientStateManager = ({
     )
 
     const [isReportModalOpen, setIsReportModalOpen] = useState(false)
+    const [isBlacklisted, setIsBlacklisted] = useState(data.isBlacklisted)
+    const instanceData = useMemo(
+        () => ({ ...data, isBlacklisted }),
+        [data, isBlacklisted]
+    )
 
     const query = useQueryParams<PGCRPageParams>(
         z.object({
@@ -123,7 +129,8 @@ export const ClientStateManager = ({
     return (
         <PGCRContext.Provider
             value={{
-                data,
+                data: instanceData,
+                setIsBlacklisted,
                 mvp,
                 playerStatsMerged: new Collection(playerStatsMerged),
                 weaponsMap,


### PR DESCRIPTION
## Summary
- Fix PGCR header content being cut off on mobile when raid names wrap to multiple lines by letting the header grow with its content instead of using a fixed height with absolute positioning
- Add a blacklist reason modal for admins on the PGCR kebab menu, replacing the previous one-click blacklist with a hardcoded reason
- Add a "Remove from Blacklist" inverse action when an instance is already blacklisted, and sync blacklist status through PGCR context so the header warning icon updates immediately

## Test plan
- [ ] Open a PGCR with a long raid name (e.g. Pantheon: Insurrection Prime Revolutionary) on a narrow/mobile viewport and confirm encounter icons and Max Feats badge are fully visible
- [ ] As an admin on a non-blacklisted instance, open the kebab menu → "Blacklist Instance" → confirm the reason modal appears and submit is disabled until a reason is entered
- [ ] After blacklisting, confirm the amber warning icon appears in the header without a page refresh
- [ ] As an admin on a blacklisted instance, confirm the kebab menu shows "Remove from Blacklist" instead of "Blacklist Instance"
- [ ] After unblacklisting, confirm the warning icon disappears and a success toast is shown
- [ ] Confirm non-admin users do not see blacklist menu options


Made with [Cursor](https://cursor.com)