### PR TITLE
Use version-specific splash images for Pantheon headers

### DIFF
--- a/src/app/leaderboards/individual/pantheon/[version]/[category]/page.tsx
+++ b/src/app/leaderboards/individual/pantheon/[version]/[category]/page.tsx
@@ -88,6 +88,7 @@ export default async function Page({
                     subtitle={`${categoryName} Leaderboard`}>
                     <CloudflareActivitySplash
                         activityId={definition.associatedActivityId!}
+                        versionId={definition.id}
                         fill
                         className="z-[-1]"
                     />

--- a/src/components/home/HomeBuckets.tsx
+++ b/src/components/home/HomeBuckets.tsx
@@ -86,12 +86,14 @@ function formatReleaseDate(iso: string | null | undefined): string | null {
 function SplashHeader({
     title,
     activityId,
+    versionId,
     releaseDate,
     expanded,
     onToggle
 }: {
     title: string
     activityId?: number | null
+    versionId?: number | null
     releaseDate?: string | null
     expanded: boolean
     onToggle: () => void
@@ -103,6 +105,7 @@ function SplashHeader({
             {activityId ? (
                 <CloudflareActivitySplash
                     activityId={activityId}
+                    versionId={versionId ?? undefined}
                     alt=""
                     fill
                     className="object-cover object-[center_30%] brightness-[0.7]"
@@ -225,6 +228,7 @@ function PantheonCard({
     const title =
         (activityId != null ? getActivityDefinition(activityId)?.name : null) ?? "The Pantheon"
     const releaseDate = activityId != null ? getActivityDefinition(activityId)?.releaseDate : null
+    const headerVersionId = versions.length > 0 ? Math.max(...versions) : null
 
     const versionGroups = useMemo(
         () =>
@@ -261,6 +265,7 @@ function PantheonCard({
             <SplashHeader
                 title={title}
                 activityId={activityId}
+                versionId={headerVersionId}
                 releaseDate={releaseDate}
                 expanded={expanded}
                 onToggle={() => setExpanded(e => !e)}

--- a/src/components/pgcr/pgcr-header-bg.tsx
+++ b/src/components/pgcr/pgcr-header-bg.tsx
@@ -5,14 +5,18 @@ import { useRaidHubManifest } from "../providers/RaidHubManifestManager"
 
 export const PGCRHeaderBackground = ({
     activityId,
+    versionId,
     children
 }: {
     activityId: number
+    versionId?: number
     children: React.ReactNode
 }) => {
-    // getRaidSplash can return null for unknown activity ids; fall back to genericRaidSplash
-    const { getImageVariantsForActivity } = useRaidHubManifest()
-    const imageVariants = getImageVariantsForActivity(activityId)
+    const { getImageVariantsForActivity, getImageVariantsForVersion } = useRaidHubManifest()
+    const imageVariants =
+        versionId != null
+            ? getImageVariantsForVersion(versionId)
+            : getImageVariantsForActivity(activityId)
     const variant = imageVariants.find(v => v.size === "small") ?? imageVariants[0]
 
     const backgroundImageUrl = variant?.url ?? FallbackSplash

--- a/src/components/pgcr/pgcr-header.tsx
+++ b/src/components/pgcr/pgcr-header.tsx
@@ -18,7 +18,7 @@ interface PGCRHeaderProps {
 
 export const PGCRHeader = ({ data }: PGCRHeaderProps) => {
     return (
-        <PGCRHeaderBackground activityId={data.activityId}>
+        <PGCRHeaderBackground activityId={data.activityId} versionId={data.versionId}>
             <div className="absolute inset-0 bg-gradient-to-r from-black/70 via-black/50 to-black/30 backdrop-blur-[2px]" />
             <CardHeader className="absolute inset-0 flex flex-col gap-2 p-2 md:p-6">
                 <div className="inline-flex gap-4">


### PR DESCRIPTION
## Summary
- Pass `versionId` to splash image components on the home pantheon card, PGCR header, and pantheon individual leaderboards
- Prefer version-level splash art from the manifest over generic activity images (e.g. show Pantheon 2 art instead of Pantheon 1)

## Test plan
- [ ] Home pantheon card shows the latest pantheon version's splash image
- [ ] PGCR pages for pantheon activities show the correct version splash in the header
- [ ] Pantheon individual leaderboard pages show version-specific splash art
- [ ] Non-pantheon raids/PGCRs still fall back to activity splash images


Made with [Cursor](https://cursor.com)