### PR TITLE
Fix instance finder Pantheon and version scoping

### DIFF
--- a/src/components/profile/raids/finder/InstanceFinderForm.tsx
+++ b/src/components/profile/raids/finder/InstanceFinderForm.tsx
@@ -87,8 +87,13 @@ export const InstanceFinderForm = ({
         name: "players"
     })
 
-    const { listedRaidIds, pantheonIds, getActivityString, getVersionString, getVersionsForActivity } =
-        useRaidHubManifest()
+    const {
+        listedRaidIds,
+        pantheonIds,
+        getActivityString,
+        getVersionString,
+        getVersionsForActivity
+    } = useRaidHubManifest()
 
     const activityOptions = useMemo(() => {
         const ids = [...listedRaidIds]
@@ -113,10 +118,12 @@ export const InstanceFinderForm = ({
         if (parsedActivityId === undefined || Number.isNaN(parsedActivityId)) {
             return []
         }
-        return getVersionsForActivity(parsedActivityId).map(version => ({
-            value: version.id,
-            label: getVersionString(version.id)
-        }))
+        return getVersionsForActivity(parsedActivityId)
+            .filter(version => version !== undefined)
+            .map(version => ({
+                value: version.id,
+                label: getVersionString(version.id)
+            }))
     }, [parsedActivityId, getVersionsForActivity, getVersionString])
 
     useEffect(() => {

--- a/src/components/profile/raids/finder/InstanceFinderForm.tsx
+++ b/src/components/profile/raids/finder/InstanceFinderForm.tsx
@@ -1,5 +1,6 @@
 import { zodResolver } from "@hookform/resolvers/zod"
 import Image from "next/image"
+import { useEffect, useMemo } from "react"
 import { FormProvider, useFieldArray, useForm, useFormContext } from "react-hook-form"
 import styled from "styled-components"
 import { type DefaultTheme } from "styled-components/dist/types"
@@ -86,17 +87,41 @@ export const InstanceFinderForm = ({
         name: "players"
     })
 
-    const { listedRaidIds, listedVerions, getActivityString, getVersionString } =
+    const { listedRaidIds, pantheonIds, getActivityString, getVersionString, getVersionsForActivity } =
         useRaidHubManifest()
-    const activityOptions = listedRaidIds.map(id => ({
-        value: id,
-        label: getActivityString(id)
-    }))
 
-    const versionOptions = listedVerions.map(id => ({
-        value: id,
-        label: getVersionString(id)
-    }))
+    const activityOptions = useMemo(() => {
+        const ids = [...listedRaidIds]
+        for (const id of pantheonIds) {
+            if (!ids.includes(id)) {
+                ids.push(id)
+            }
+        }
+        return ids.map(id => ({
+            value: id,
+            label: getActivityString(id)
+        }))
+    }, [listedRaidIds, pantheonIds, getActivityString])
+
+    const selectedActivityId = form.watch("activityId")
+    const parsedActivityId =
+        selectedActivityId === "" || selectedActivityId === undefined
+            ? undefined
+            : Number(selectedActivityId)
+
+    const versionOptions = useMemo(() => {
+        if (parsedActivityId === undefined || Number.isNaN(parsedActivityId)) {
+            return []
+        }
+        return getVersionsForActivity(parsedActivityId).map(version => ({
+            value: version.id,
+            label: getVersionString(version.id)
+        }))
+    }, [parsedActivityId, getVersionsForActivity, getVersionString])
+
+    useEffect(() => {
+        form.setValue("versionId", undefined)
+    }, [parsedActivityId, form])
 
     const seasonsOptions =
         useSeasons({ reversed: true })

--- a/src/components/profile/raids/finder/InstanceFinderForm.tsx
+++ b/src/components/profile/raids/finder/InstanceFinderForm.tsx
@@ -127,7 +127,7 @@ export const InstanceFinderForm = ({
     }, [parsedActivityId, getVersionsForActivity, getVersionString])
 
     useEffect(() => {
-        form.setValue("versionId", undefined)
+        form.setValue("versionId", "")
     }, [parsedActivityId, form])
 
     const seasonsOptions =


### PR DESCRIPTION
## Summary
- Add Pantheon activities to the instance finder activity dropdown (they are not in `listedRaidIds` because `is_raid` is false)
- Scope the version dropdown to versions for the selected activity using `getVersionsForActivity`
- Clear the selected version when the activity changes

## Test plan
- [ ] Open profile → Instance Finder
- [ ] Confirm Pantheon activities (e.g. Monument of Triumph) appear in the Activity dropdown
- [ ] Select a raid and verify Version only shows versions for that raid
- [ ] Change activity and confirm version selection resets
- [ ] Search with Pantheon activity + version and confirm results return


Made with [Cursor](https://cursor.com)