### PR TITLE
Redesign PGCR team stats and weapons section

### DIFF
--- a/src/components/pgcr/pgcr-players.tsx
+++ b/src/components/pgcr/pgcr-players.tsx
@@ -1,7 +1,7 @@
 import { type Collection } from "@discordjs/collection"
 import { Fragment } from "react"
-import PlayerRow from "~/components/pgcr/player-row"
 import { PGCRTeamSummary } from "~/components/pgcr/pgcr-team-summary"
+import PlayerRow from "~/components/pgcr/player-row"
 import { type PlayerStats } from "~/lib/pgcr/types"
 import { type RaidHubInstanceExtended } from "~/services/raidhub/types"
 import { CardContent } from "~/shad/card"
@@ -36,10 +36,14 @@ export const PGCRPlayers = ({ data, mvp, playerMergedStats, sortScores }: PGCRPl
     const bestKDPlayer = data.players.find(p => p.playerInfo.membershipId === bestKD)!
     const mostMelee = playerMergedStats.sort((a, b) => b.meleeKills - a.meleeKills).firstKey()!
     const mostMeleePlayer = data.players.find(p => p.playerInfo.membershipId === mostMelee)!
-    const mostGrenades = playerMergedStats.sort((a, b) => b.grenadeKills - a.grenadeKills).firstKey()!
+    const mostGrenades = playerMergedStats
+        .sort((a, b) => b.grenadeKills - a.grenadeKills)
+        .firstKey()!
     const mostGrenadesPlayer = data.players.find(p => p.playerInfo.membershipId === mostGrenades)!
     const mostSuperKills = playerMergedStats.sort((a, b) => b.superKills - a.superKills).firstKey()!
-    const mostSuperKillsPlayer = data.players.find(p => p.playerInfo.membershipId === mostSuperKills)!
+    const mostSuperKillsPlayer = data.players.find(
+        p => p.playerInfo.membershipId === mostSuperKills
+    )!
 
     const totals = playerMergedStats.reduce(
         (acc, stats) => ({

--- a/src/components/pgcr/pgcr-players.tsx
+++ b/src/components/pgcr/pgcr-players.tsx
@@ -1,13 +1,12 @@
 import { type Collection } from "@discordjs/collection"
-import { Sword, Trophy } from "lucide-react"
 import { Fragment } from "react"
 import PlayerRow from "~/components/pgcr/player-row"
+import { PGCRTeamSummary } from "~/components/pgcr/pgcr-team-summary"
 import { type PlayerStats } from "~/lib/pgcr/types"
 import { type RaidHubInstanceExtended } from "~/services/raidhub/types"
-import { Card, CardContent, CardHeader } from "~/shad/card"
+import { CardContent } from "~/shad/card"
 import { ScrollArea } from "~/shad/scroll-area"
 import { Separator } from "~/shad/separator"
-import { getBungieDisplayName } from "~/util/destiny"
 import { AllPgcrWeaponsWrapper } from "./pgcr-weapons"
 
 interface PGCRPlayersProps {
@@ -27,14 +26,20 @@ export const PGCRPlayers = ({ data, mvp, playerMergedStats, sortScores }: PGCRPl
     const mvpPlayer = mvp ? data.players.find(p => p.playerInfo.membershipId === mvp)! : null
     const mostKills = playerMergedStats.sort((a, b) => b.kills - a.kills).firstKey()!
     const mostKillsPlayer = data.players.find(p => p.playerInfo.membershipId === mostKills)!
-    const mostAssists = playerMergedStats.sort((a, b) => b.assists - a.assists).firstKey()!
-    const mostAssistsPlayer = data.players.find(p => p.playerInfo.membershipId === mostAssists)!
     const mostDeaths = playerMergedStats.sort((a, b) => b.deaths - a.deaths).firstKey()!
     const mostDeathsPlayer = data.players.find(p => p.playerInfo.membershipId === mostDeaths)!
+    const mostAssists = playerMergedStats.sort((a, b) => b.assists - a.assists).firstKey()!
+    const mostAssistsPlayer = data.players.find(p => p.playerInfo.membershipId === mostAssists)!
     const bestKD = playerMergedStats
         .sort((a, b) => b.kills / (b.deaths || 1) - a.kills / (a.deaths || 1))
         .firstKey()!
     const bestKDPlayer = data.players.find(p => p.playerInfo.membershipId === bestKD)!
+    const mostMelee = playerMergedStats.sort((a, b) => b.meleeKills - a.meleeKills).firstKey()!
+    const mostMeleePlayer = data.players.find(p => p.playerInfo.membershipId === mostMelee)!
+    const mostGrenades = playerMergedStats.sort((a, b) => b.grenadeKills - a.grenadeKills).firstKey()!
+    const mostGrenadesPlayer = data.players.find(p => p.playerInfo.membershipId === mostGrenades)!
+    const mostSuperKills = playerMergedStats.sort((a, b) => b.superKills - a.superKills).firstKey()!
+    const mostSuperKillsPlayer = data.players.find(p => p.playerInfo.membershipId === mostSuperKills)!
 
     const totals = playerMergedStats.reduce(
         (acc, stats) => ({
@@ -64,6 +69,80 @@ export const PGCRPlayers = ({ data, mvp, playerMergedStats, sortScores }: PGCRPl
     const _bestKdPlayerStats = playerMergedStats.get(bestKD)!
     const bestKd = _bestKdPlayerStats.kills / (_bestKdPlayerStats.deaths || 1)
 
+    const teamSummaryColumns = [
+        {
+            label: "Kills",
+            teamValue: totals.kills.toLocaleString(),
+            leaders: [
+                {
+                    player: mostKillsPlayer,
+                    value: playerMergedStats.get(mostKills)!.kills.toLocaleString()
+                }
+            ]
+        },
+        {
+            label: "Deaths",
+            teamValue: totals.deaths.toLocaleString(),
+            leaders: [
+                {
+                    player: mostDeathsPlayer,
+                    value: playerMergedStats.get(mostDeaths)!.deaths.toLocaleString(),
+                    accent: totals.deaths > 0 ? ("deaths" as const) : undefined
+                }
+            ]
+        },
+        {
+            label: "Assists",
+            teamValue: totals.assists.toLocaleString(),
+            leaders: [
+                {
+                    player: mostAssistsPlayer,
+                    value: playerMergedStats.get(mostAssists)!.assists.toLocaleString()
+                }
+            ]
+        },
+        {
+            label: "K/D",
+            teamValue: totalKd.toFixed(2),
+            leaders: [
+                {
+                    player: bestKDPlayer,
+                    value: bestKd.toFixed(2)
+                }
+            ]
+        },
+        {
+            label: "Melee Kills",
+            teamValue: totals.meleeKills.toLocaleString(),
+            leaders: [
+                {
+                    player: mostMeleePlayer,
+                    value: playerMergedStats.get(mostMelee)!.meleeKills.toLocaleString()
+                }
+            ]
+        },
+        {
+            label: "Grenade Kills",
+            teamValue: totals.grenadeKills.toLocaleString(),
+            leaders: [
+                {
+                    player: mostGrenadesPlayer,
+                    value: playerMergedStats.get(mostGrenades)!.grenadeKills.toLocaleString()
+                }
+            ]
+        },
+        {
+            label: "Super Kills",
+            teamValue: totals.superKills.toLocaleString(),
+            leaders: [
+                {
+                    player: mostSuperKillsPlayer,
+                    value: playerMergedStats.get(mostSuperKills)!.superKills.toLocaleString()
+                }
+            ]
+        }
+    ]
+
     return (
         <CardContent className="space-y-6 bg-black p-2 md:p-6">
             {/* Players Section */}
@@ -74,7 +153,7 @@ export const PGCRPlayers = ({ data, mvp, playerMergedStats, sortScores }: PGCRPl
                     <div className="text-center">Kills</div>
                     <div className="text-center">Deaths</div>
                     <div className="hidden text-center md:block">Assists</div>
-                    <div className="hidden text-center md:block">K/D</div>
+                    <div className="hidden text-center md:block">Kill Share</div>
                     <div className="text-center">Time</div>
                 </div>
 
@@ -90,108 +169,11 @@ export const PGCRPlayers = ({ data, mvp, playerMergedStats, sortScores }: PGCRPl
                 </ScrollArea>
             </div>
 
-            {/* Activity Summary Section */}
-
             {data.playerCount > 1 && (
-                <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-                    <Card className="rounded-none border-zinc-800 bg-zinc-950">
-                        <CardHeader>
-                            <h3 className="flex items-center gap-2 text-base font-medium md:text-lg">
-                                <Trophy className="text-raidhub h-4 w-4 md:h-5 md:w-5" />
-                                Activity Highlights
-                            </h3>
-                        </CardHeader>
-                        <CardContent className="space-y-3 p-4 pt-0">
-                            {mvpPlayer && (
-                                <>
-                                    <LabeledStat
-                                        label="MVP"
-                                        value={getBungieDisplayName(mvpPlayer.playerInfo, {
-                                            excludeCode: true
-                                        })}
-                                    />
-                                    <Separator className="bg-zinc-800" />
-                                </>
-                            )}
-                            <LabeledStat
-                                label="Most Kills"
-                                value={`${getBungieDisplayName(mostKillsPlayer.playerInfo, {
-                                    excludeCode: true
-                                })} - ${playerMergedStats.get(mostKills)!.kills.toLocaleString()}`}
-                            />
-                            <Separator className="bg-zinc-800" />
-                            <LabeledStat
-                                label="Most Assists"
-                                value={`${getBungieDisplayName(mostAssistsPlayer.playerInfo, {
-                                    excludeCode: true
-                                })} - ${playerMergedStats.get(mostAssists)!.assists.toLocaleString()}`}
-                            />
-                            <Separator className="bg-zinc-800" />
-                            <LabeledStat
-                                label="Best K/D"
-                                value={`${getBungieDisplayName(bestKDPlayer.playerInfo, {
-                                    excludeCode: true
-                                })} - ${bestKd.toFixed(2)}`}
-                            />
-                            {totals.deaths > 0 && (
-                                <>
-                                    <Separator className="bg-zinc-800" />
-                                    <LabeledStat
-                                        label="Most Deaths"
-                                        value={`${getBungieDisplayName(
-                                            mostDeathsPlayer.playerInfo,
-                                            {
-                                                excludeCode: true
-                                            }
-                                        )} - ${playerMergedStats.get(mostDeaths)!.deaths.toLocaleString()}`}
-                                    />
-                                </>
-                            )}
-                        </CardContent>
-                    </Card>
-
-                    <Card className="rounded-none border-zinc-800 bg-zinc-950">
-                        <CardHeader>
-                            <h3 className="flex items-center gap-2 text-base font-medium md:text-lg">
-                                <Sword className="text-raidhub h-4 w-4 md:h-5 md:w-5" />
-                                Combat Stats
-                            </h3>
-                        </CardHeader>
-                        <CardContent className="space-y-3 p-4 pt-0">
-                            <LabeledStat
-                                label="Total Kills"
-                                value={totals.kills.toLocaleString()}
-                            />
-                            <Separator className="bg-zinc-800" />
-                            <LabeledStat
-                                label="Total Assists"
-                                value={totals.assists.toLocaleString()}
-                            />
-                            <Separator className="bg-zinc-800" />
-                            <LabeledStat
-                                label="Total Deaths"
-                                value={totals.deaths.toLocaleString()}
-                            />
-                            <Separator className="bg-zinc-800" />
-                            <LabeledStat label="Team K/D" value={totalKd.toFixed(2)} />
-                            <Separator className="bg-zinc-800" />
-                            <LabeledStat
-                                label="Total Super Kills"
-                                value={totals.superKills.toLocaleString()}
-                            />
-                        </CardContent>
-                    </Card>
-                </div>
+                <PGCRTeamSummary mvp={mvpPlayer ?? undefined} columns={teamSummaryColumns} />
             )}
 
             <AllPgcrWeaponsWrapper {...totals} />
         </CardContent>
     )
 }
-
-const LabeledStat = ({ label, value }: { label: string; value: string }) => (
-    <div className="flex items-center justify-between">
-        <span className="text-sm text-zinc-400">{label}</span>
-        <span className="text-sm font-medium">{value}</span>
-    </div>
-)

--- a/src/components/pgcr/pgcr-team-summary.tsx
+++ b/src/components/pgcr/pgcr-team-summary.tsx
@@ -32,7 +32,9 @@ export function PGCRTeamSummary({ mvp, columns }: PGCRTeamSummaryProps) {
             <div className="overflow-x-auto">
                 <div
                     className="grid min-w-max divide-x divide-zinc-800"
-                    style={{ gridTemplateColumns: `repeat(${columns.length}, minmax(7.5rem, 1fr))` }}>
+                    style={{
+                        gridTemplateColumns: `repeat(${columns.length}, minmax(7.5rem, 1fr))`
+                    }}>
                     {columns.map(column => (
                         <SummaryColumn key={column.label} {...column} />
                     ))}
@@ -50,7 +52,10 @@ const MvpBanner = ({ player }: { player: RaidHubInstancePlayerExtended }) => {
             href={`/profile/${player.playerInfo.membershipId}`}
             className="group flex items-center gap-2 border-b border-zinc-800 bg-yellow-500/[0.04] px-3 py-2 transition-colors hover:bg-yellow-500/[0.07] md:gap-3 md:px-4 md:py-2.5">
             <Avatar className="size-7 flex-shrink-0 rounded-sm md:size-8">
-                <AvatarImage src={bungieProfileIconUrl(player.playerInfo.iconPath)} alt={displayName} />
+                <AvatarImage
+                    src={bungieProfileIconUrl(player.playerInfo.iconPath)}
+                    alt={displayName}
+                />
                 <AvatarFallback className="rounded-sm bg-zinc-800 text-xs">
                     {displayName.charAt(0).toLocaleUpperCase()}
                 </AvatarFallback>
@@ -70,8 +75,12 @@ const MvpBanner = ({ player }: { player: RaidHubInstancePlayerExtended }) => {
 const SummaryColumn = ({ label, teamValue, leaders }: TeamSummaryColumn) => (
     <div className="flex min-w-[7.5rem] flex-col">
         <div className="border-b border-zinc-800 px-3 py-3 text-center md:px-4 md:py-4">
-            <div className="text-primary/90 text-xl font-semibold tabular-nums md:text-2xl">{teamValue}</div>
-            <div className="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">{label}</div>
+            <div className="text-primary/90 text-xl font-semibold tabular-nums md:text-2xl">
+                {teamValue}
+            </div>
+            <div className="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">
+                {label}
+            </div>
         </div>
         <div className="flex flex-1 flex-col">
             {leaders.map((leader, index) => (
@@ -103,13 +112,18 @@ const ColumnLeader = ({
                 accent === "deaths" && "bg-zinc-900/40"
             )}>
             <Avatar className="size-6 flex-shrink-0 rounded-sm md:size-7">
-                <AvatarImage src={bungieProfileIconUrl(player.playerInfo.iconPath)} alt={displayName} />
+                <AvatarImage
+                    src={bungieProfileIconUrl(player.playerInfo.iconPath)}
+                    alt={displayName}
+                />
                 <AvatarFallback className="rounded-sm bg-zinc-800 text-[10px]">
                     {displayName.charAt(0).toLocaleUpperCase()}
                 </AvatarFallback>
             </Avatar>
             <div className="w-full min-w-0">
-                <div className="truncate text-xs font-medium group-hover:text-white">{displayName}</div>
+                <div className="truncate text-xs font-medium group-hover:text-white">
+                    {displayName}
+                </div>
                 {caption && (
                     <div className="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">
                         {caption}

--- a/src/components/pgcr/pgcr-team-summary.tsx
+++ b/src/components/pgcr/pgcr-team-summary.tsx
@@ -1,0 +1,128 @@
+"use client"
+
+import Link from "next/link"
+import { cn } from "~/lib/tw"
+import { type RaidHubInstancePlayerExtended } from "~/services/raidhub/types"
+import { Avatar, AvatarFallback, AvatarImage } from "~/shad/avatar"
+import { bungieProfileIconUrl, getBungieDisplayName } from "~/util/destiny"
+
+export interface ColumnLeaderEntry {
+    player: RaidHubInstancePlayerExtended
+    value: string
+    caption?: string
+    accent?: "deaths"
+}
+
+export interface TeamSummaryColumn {
+    label: string
+    teamValue: string
+    leaders: ColumnLeaderEntry[]
+}
+
+interface PGCRTeamSummaryProps {
+    mvp?: RaidHubInstancePlayerExtended
+    columns: TeamSummaryColumn[]
+}
+
+export function PGCRTeamSummary({ mvp, columns }: PGCRTeamSummaryProps) {
+    return (
+        <div className="overflow-hidden rounded-lg border border-zinc-800 bg-zinc-950">
+            {mvp && <MvpBanner player={mvp} />}
+
+            <div className="overflow-x-auto">
+                <div
+                    className="grid min-w-max divide-x divide-zinc-800"
+                    style={{ gridTemplateColumns: `repeat(${columns.length}, minmax(7.5rem, 1fr))` }}>
+                    {columns.map(column => (
+                        <SummaryColumn key={column.label} {...column} />
+                    ))}
+                </div>
+            </div>
+        </div>
+    )
+}
+
+const MvpBanner = ({ player }: { player: RaidHubInstancePlayerExtended }) => {
+    const displayName = getBungieDisplayName(player.playerInfo, { excludeCode: true })
+
+    return (
+        <Link
+            href={`/profile/${player.playerInfo.membershipId}`}
+            className="group flex items-center gap-2 border-b border-zinc-800 bg-yellow-500/[0.04] px-3 py-2 transition-colors hover:bg-yellow-500/[0.07] md:gap-3 md:px-4 md:py-2.5">
+            <Avatar className="size-7 flex-shrink-0 rounded-sm md:size-8">
+                <AvatarImage src={bungieProfileIconUrl(player.playerInfo.iconPath)} alt={displayName} />
+                <AvatarFallback className="rounded-sm bg-zinc-800 text-xs">
+                    {displayName.charAt(0).toLocaleUpperCase()}
+                </AvatarFallback>
+            </Avatar>
+            <div className="min-w-0">
+                <div className="text-[10px] font-medium tracking-wider text-yellow-500/80 uppercase">
+                    MVP
+                </div>
+                <div className="truncate text-sm font-medium group-hover:text-white">
+                    {displayName}
+                </div>
+            </div>
+        </Link>
+    )
+}
+
+const SummaryColumn = ({ label, teamValue, leaders }: TeamSummaryColumn) => (
+    <div className="flex min-w-[7.5rem] flex-col">
+        <div className="border-b border-zinc-800 px-3 py-3 text-center md:px-4 md:py-4">
+            <div className="text-primary/90 text-xl font-semibold tabular-nums md:text-2xl">{teamValue}</div>
+            <div className="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">{label}</div>
+        </div>
+        <div className="flex flex-1 flex-col">
+            {leaders.map((leader, index) => (
+                <ColumnLeader
+                    key={`${leader.player.playerInfo.membershipId}-${leader.caption ?? index}`}
+                    {...leader}
+                    bordered={index > 0}
+                />
+            ))}
+        </div>
+    </div>
+)
+
+const ColumnLeader = ({
+    player,
+    value,
+    caption,
+    accent,
+    bordered
+}: ColumnLeaderEntry & { bordered?: boolean }) => {
+    const displayName = getBungieDisplayName(player.playerInfo, { excludeCode: true })
+
+    return (
+        <Link
+            href={`/profile/${player.playerInfo.membershipId}`}
+            className={cn(
+                "group flex flex-1 flex-col items-center gap-1.5 px-2 py-2.5 text-center transition-colors hover:bg-zinc-900/80 md:gap-2 md:px-3 md:py-3",
+                bordered && "border-t border-zinc-800",
+                accent === "deaths" && "bg-zinc-900/40"
+            )}>
+            <Avatar className="size-6 flex-shrink-0 rounded-sm md:size-7">
+                <AvatarImage src={bungieProfileIconUrl(player.playerInfo.iconPath)} alt={displayName} />
+                <AvatarFallback className="rounded-sm bg-zinc-800 text-[10px]">
+                    {displayName.charAt(0).toLocaleUpperCase()}
+                </AvatarFallback>
+            </Avatar>
+            <div className="w-full min-w-0">
+                <div className="truncate text-xs font-medium group-hover:text-white">{displayName}</div>
+                {caption && (
+                    <div className="text-[10px] font-medium tracking-wider text-zinc-500 uppercase">
+                        {caption}
+                    </div>
+                )}
+                <div
+                    className={cn(
+                        "mt-0.5 text-lg font-semibold tabular-nums md:text-xl",
+                        accent === "deaths" ? "text-zinc-400" : "text-primary/90"
+                    )}>
+                    {value}
+                </div>
+            </div>
+        </Link>
+    )
+}

--- a/src/components/pgcr/pgcr-weapons.tsx
+++ b/src/components/pgcr/pgcr-weapons.tsx
@@ -1,15 +1,11 @@
 "use client"
 
 import { Collection } from "@discordjs/collection"
-import { Crosshair, Swords } from "lucide-react"
 import Image from "next/image"
 import Link from "next/link"
 import { useMemo } from "react"
 import { usePGCRContext } from "~/hooks/pgcr/ClientStateManager"
 import { type PlayerStats } from "~/lib/pgcr/types"
-import { Badge } from "~/shad/badge"
-import { Card, CardContent, CardHeader } from "~/shad/card"
-import { Progress } from "~/shad/progress"
 import { Tooltip, TooltipContent, TooltipTrigger } from "~/shad/tooltip"
 import { bungieItemUrl, getBungieDisplayName } from "~/util/destiny"
 
@@ -18,6 +14,11 @@ interface WeaponData {
     precisionKills: number
     users: Set<string>
 }
+
+const KINETIC_BUCKET = 1498876634
+const ENERGY_BUCKET = 2465295065
+const POWER_BUCKET = 953998645
+
 export const WeaponTable = ({
     kineticWeapons,
     energyWeapons,
@@ -32,107 +33,76 @@ export const WeaponTable = ({
     showUsers: boolean
 }) => {
     const { weaponsMap } = usePGCRContext()
+
+    const slots = [
+        { label: "Kinetic", weapons: kineticWeapons },
+        { label: "Energy", weapons: energyWeapons },
+        { label: "Power", weapons: powerWeapons }
+    ].filter(slot => slot.weapons.size > 0)
+
+    if (slots.length === 0) {
+        return null
+    }
+
     return (
-        <Card className="gap-2 rounded-none border-zinc-800 bg-zinc-950">
-            <CardHeader className="pb-0">
-                <h3 className="flex items-center gap-2 text-base font-medium md:text-lg">
-                    <Swords className="text-raidhub h-4 w-4 md:h-5 md:w-5" />
-                    Weapons
-                </h3>
-            </CardHeader>
-            <CardContent>
-                <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
-                    {/* Kinetic Weapons */}
-                    <div>
-                        <div className="mb-3 flex items-center">
-                            <Badge
-                                variant="outline"
-                                className="border-zinc-200/20 bg-zinc-200/10 text-zinc-200">
-                                Kinetic
-                            </Badge>
-                        </div>
-                        <div className="space-y-3">
-                            {kineticWeapons.map((weapon, hash) => (
-                                <WeaponCard
-                                    weaponHash={hash}
-                                    key={hash}
-                                    kills={weapon.kills}
-                                    precisionKills={weapon.precisionKills}
-                                    characterKills={stats.kills}
-                                    weaponName={
-                                        weaponsMap.get(hash)?.displayProperties.name ?? "Unknown"
-                                    }
-                                    icon={weaponsMap.get(hash)?.displayProperties.icon ?? ""}
-                                    users={weapon.users}
-                                    showUsers={showUsers}
-                                />
-                            ))}
-                        </div>
-                    </div>
-                    {/* Energy Weapons */}
-                    <div>
-                        <div className="mb-3 flex items-center">
-                            <Badge
-                                variant="outline"
-                                className="border-green-400/20 bg-green-400/10 text-green-400">
-                                Energy
-                            </Badge>
-                        </div>
-                        <div className="space-y-3">
-                            {energyWeapons.map((weapon, hash) => (
-                                <WeaponCard
-                                    weaponHash={hash}
-                                    key={hash}
-                                    kills={weapon.kills}
-                                    precisionKills={weapon.precisionKills}
-                                    characterKills={stats.kills}
-                                    weaponName={
-                                        weaponsMap.get(hash)?.displayProperties.name ?? "Unknown"
-                                    }
-                                    icon={weaponsMap.get(hash)?.displayProperties.icon ?? ""}
-                                    users={weapon.users}
-                                    showUsers={showUsers}
-                                />
-                            ))}
-                        </div>
-                    </div>
-                    {/* Power Weapons */}
-                    <div>
-                        <div className="mb-3 flex items-center">
-                            <Badge
-                                variant="outline"
-                                className="border-purple-400/20 bg-purple-400/10 text-purple-400">
-                                Power
-                            </Badge>
-                        </div>
-                        <div className="space-y-3">
-                            {powerWeapons.map((weapon, hash) => (
-                                <WeaponCard
-                                    key={hash}
-                                    weaponHash={hash}
-                                    kills={weapon.kills}
-                                    precisionKills={weapon.precisionKills}
-                                    characterKills={stats.kills}
-                                    weaponName={
-                                        weaponsMap.get(hash)?.displayProperties.name ?? "Unknown"
-                                    }
-                                    icon={weaponsMap.get(hash)?.displayProperties.icon ?? ""}
-                                    users={weapon.users}
-                                    showUsers={showUsers}
-                                />
-                            ))}
-                        </div>
-                    </div>
-                </div>
-            </CardContent>
-        </Card>
+        <div className="overflow-x-auto rounded-lg border border-zinc-800 bg-zinc-950">
+            <div
+                className="grid min-w-max divide-x divide-zinc-800"
+                style={{ gridTemplateColumns: `repeat(${slots.length}, minmax(11rem, 1fr))` }}>
+                {slots.map(slot => (
+                    <WeaponSlot
+                        key={slot.label}
+                        label={slot.label}
+                        weapons={slot.weapons}
+                        weaponsMap={weaponsMap}
+                        totalKills={stats.kills}
+                        showUsers={showUsers}
+                    />
+                ))}
+            </div>
+        </div>
     )
 }
 
-interface WeaponCardProps {
+const WeaponSlot = ({
+    label,
+    weapons,
+    weaponsMap,
+    totalKills,
+    showUsers
+}: {
+    label: string
+    weapons: Collection<number, WeaponData>
+    weaponsMap: ReturnType<typeof usePGCRContext>["weaponsMap"]
+    totalKills: number
+    showUsers: boolean
+}) => (
+    <div className="min-w-[11rem]">
+        <div className="border-b border-zinc-800 px-3 py-2 text-center text-[10px] font-medium tracking-wider text-zinc-500 uppercase">
+            {label}
+        </div>
+        <div className="divide-y divide-zinc-800">
+            {weapons.map((weapon, hash) => (
+                <WeaponRow
+                    key={hash}
+                    weaponHash={hash}
+                    kills={weapon.kills}
+                    precisionKills={weapon.precisionKills}
+                    totalKills={totalKills}
+                    weaponName={weaponsMap.get(hash)?.displayProperties.name ?? "Unknown"}
+                    icon={weaponsMap.get(hash)?.displayProperties.icon ?? ""}
+                    users={weapon.users}
+                    showUsers={showUsers}
+                />
+            ))}
+        </div>
+    </div>
+)
+
+interface WeaponRowProps {
     kills: number
     precisionKills: number
-    characterKills: number
+    totalKills: number
     weaponHash: number
     icon: string
     weaponName: string
@@ -140,83 +110,73 @@ interface WeaponCardProps {
     showUsers: boolean
 }
 
-export const WeaponCard = ({
+const WeaponRow = ({
     kills,
     precisionKills,
-    characterKills: totalPlayerKills,
+    totalKills,
     weaponName,
     icon,
     users,
     showUsers,
     weaponHash
-}: WeaponCardProps) => {
+}: WeaponRowProps) => {
     const { data } = usePGCRContext()
-    const getName = (id: string) => {
-        return getBungieDisplayName(
-            data.players.find(player => player.playerInfo.membershipId === id)!.playerInfo,
-            { excludeCode: true }
-        )
-    }
     const imageUrl = bungieItemUrl(icon ?? "")
+    const sharePct = totalKills > 0 ? (kills / totalKills) * 100 : 0
+    const precisionPct = kills > 0 ? (100 * precisionKills) / kills : 0
+
     return (
-        <Card className="overflow-hidden rounded-none border-zinc-800 bg-zinc-950 py-0">
-            <CardContent className="p-0">
-                <div className="flex items-center">
-                    <div className="flex size-12 flex-shrink-0 items-center justify-center overflow-hidden bg-zinc-800 md:size-16">
-                        {imageUrl && (
-                            <Image
-                                unoptimized
-                                src={imageUrl}
-                                alt={weaponName}
-                                className="h-full w-full object-contain"
-                                width={96}
-                                height={96}
-                            />
-                        )}
-                    </div>
-                    <div className="flex-1 space-y-1 p-3">
-                        <div className="flex items-center justify-between gap-1">
-                            <Link
-                                className="text-primary text-xs font-medium md:text-sm"
-                                target="_blank"
-                                rel="noopener"
-                                href={`https://d2foundry.gg/w/${weaponHash}`}>
-                                {weaponName}
-                            </Link>
-                            <div className="text-lg font-medium">{kills}</div>
-                        </div>
-                        <div className="hidden items-center gap-2 md:flex">
-                            <Progress
-                                value={(kills / totalPlayerKills) * 100}
-                                className="h-1.5 flex-1"
-                            />
-                            <span className="text-xs whitespace-nowrap text-zinc-500">
-                                {((kills / totalPlayerKills) * 100).toFixed(1)}%
+        <div className="flex items-center gap-2 px-2 py-2 md:gap-3 md:px-3">
+            <div className="flex size-8 shrink-0 items-center justify-center overflow-hidden bg-zinc-800 md:size-9">
+                {imageUrl && (
+                    <Image
+                        unoptimized
+                        src={imageUrl}
+                        alt={weaponName}
+                        className="h-full w-full object-contain"
+                        width={72}
+                        height={72}
+                    />
+                )}
+            </div>
+            <div className="min-w-0 flex-1">
+                <Link
+                    className="block truncate text-xs font-medium hover:text-white md:text-sm"
+                    target="_blank"
+                    rel="noopener"
+                    href={`https://d2foundry.gg/w/${weaponHash}`}>
+                    {weaponName}
+                </Link>
+                {showUsers ? (
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <span className="text-[10px] text-zinc-500">
+                                {users.size} player{users.size !== 1 ? "s" : ""}
                             </span>
-                        </div>
-                        <div className="hidden justify-end md:flex">
-                            <Tooltip>
-                                <TooltipTrigger asChild>
-                                    <span className="flex items-center gap-1 text-xs text-zinc-400">
-                                        {showUsers
-                                            ? `${users.size} player${users.size !== 1 ? "s" : ""}`
-                                            : `${((100 * precisionKills) / kills).toFixed(0)}% precision`}
-                                        {!showUsers && <Crosshair className="h-3 w-3" />}
-                                    </span>
-                                </TooltipTrigger>
-                                {showUsers && (
-                                    <TooltipContent>
-                                        {Array.from(users).map(user => (
-                                            <div key={user}>{getName(user)}</div>
-                                        ))}
-                                    </TooltipContent>
-                                )}
-                            </Tooltip>
-                        </div>
-                    </div>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            {Array.from(users).map(id => (
+                                <div key={id}>{getBungieDisplayName(
+                                    data.players.find(player => player.playerInfo.membershipId === id)!
+                                        .playerInfo,
+                                    { excludeCode: true }
+                                )}</div>
+                            ))}
+                        </TooltipContent>
+                    </Tooltip>
+                ) : (
+                    <span className="text-[10px] text-zinc-500">
+                        {precisionPct.toFixed(0)}% precision
+                    </span>
+                )}
+            </div>
+            <div className="shrink-0 text-right">
+                <div className="text-primary/90 text-sm font-semibold tabular-nums md:text-base">
+                    {kills.toLocaleString()}
                 </div>
-            </CardContent>
-        </Card>
+                <div className="text-[10px] tabular-nums text-zinc-500">{sharePct.toFixed(1)}%</div>
+            </div>
+        </div>
     )
 }
 
@@ -225,7 +185,6 @@ export const AllPgcrWeaponsWrapper = (stats: PlayerStats) => {
     const { kineticWeapons, energyWeapons, powerWeapons } = useMemo(() => {
         const weaponStats = new Collection<number, WeaponData>()
         data.players.forEach(player => {
-            const weaponSet = new Set<number>()
             player.characters.forEach(character => {
                 character.weapons.forEach(weapon => {
                     const prev = weaponStats.get(weapon.weaponHash)
@@ -236,30 +195,19 @@ export const AllPgcrWeaponsWrapper = (stats: PlayerStats) => {
                             player.playerInfo.membershipId
                         )
                     })
-                    weaponSet.add(weapon.weaponHash)
                 })
             })
         })
 
         weaponStats.sort((a, b) => b.kills - a.kills)
 
-        const kineticWeapons = weaponStats.filter((_, key) => {
-            const weapon = weaponsMap.get(key)
-            return weapon?.inventory?.bucketTypeHash === 1498876634
-        })
-        const energyWeapons = weaponStats.filter((_, key) => {
-            const weapon = weaponsMap.get(key)
-            return weapon?.inventory?.bucketTypeHash === 2465295065
-        })
+        const byBucket = (bucketHash: number) =>
+            weaponStats.filter((_, key) => weaponsMap.get(key)?.inventory?.bucketTypeHash === bucketHash)
 
-        const powerWeapons = weaponStats.filter((_, key) => {
-            const weapon = weaponsMap.get(key)
-            return weapon?.inventory?.bucketTypeHash === 953998645
-        })
         return {
-            kineticWeapons,
-            energyWeapons,
-            powerWeapons
+            kineticWeapons: byBucket(KINETIC_BUCKET),
+            energyWeapons: byBucket(ENERGY_BUCKET),
+            powerWeapons: byBucket(POWER_BUCKET)
         }
     }, [data, weaponsMap])
 

--- a/src/components/pgcr/pgcr-weapons.tsx
+++ b/src/components/pgcr/pgcr-weapons.tsx
@@ -156,11 +156,14 @@ const WeaponRow = ({
                         </TooltipTrigger>
                         <TooltipContent>
                             {Array.from(users).map(id => (
-                                <div key={id}>{getBungieDisplayName(
-                                    data.players.find(player => player.playerInfo.membershipId === id)!
-                                        .playerInfo,
-                                    { excludeCode: true }
-                                )}</div>
+                                <div key={id}>
+                                    {getBungieDisplayName(
+                                        data.players.find(
+                                            player => player.playerInfo.membershipId === id
+                                        )!.playerInfo,
+                                        { excludeCode: true }
+                                    )}
+                                </div>
                             ))}
                         </TooltipContent>
                     </Tooltip>
@@ -174,7 +177,7 @@ const WeaponRow = ({
                 <div className="text-primary/90 text-sm font-semibold tabular-nums md:text-base">
                     {kills.toLocaleString()}
                 </div>
-                <div className="text-[10px] tabular-nums text-zinc-500">{sharePct.toFixed(1)}%</div>
+                <div className="text-[10px] text-zinc-500 tabular-nums">{sharePct.toFixed(1)}%</div>
             </div>
         </div>
     )
@@ -202,7 +205,9 @@ export const AllPgcrWeaponsWrapper = (stats: PlayerStats) => {
         weaponStats.sort((a, b) => b.kills - a.kills)
 
         const byBucket = (bucketHash: number) =>
-            weaponStats.filter((_, key) => weaponsMap.get(key)?.inventory?.bucketTypeHash === bucketHash)
+            weaponStats.filter(
+                (_, key) => weaponsMap.get(key)?.inventory?.bucketTypeHash === bucketHash
+            )
 
         return {
             kineticWeapons: byBucket(KINETIC_BUCKET),

--- a/src/components/pgcr/player-row.tsx
+++ b/src/components/pgcr/player-row.tsx
@@ -1,8 +1,8 @@
 "use client"
 
+import { useMemo } from "react"
 import { ChevronRight, SquareArrowLeft } from "lucide-react"
 import Link from "next/link"
-import { ActivityPieChart } from "~/components/pgcr/activity-pie-chart"
 import { useItemDefinition } from "~/hooks/dexie"
 import { usePGCRContext } from "~/hooks/pgcr/ClientStateManager"
 import { useGetCharacterClass } from "~/hooks/pgcr/useCharacterClass"
@@ -24,6 +24,13 @@ export default function PlayerRow({ player }: PlayerRowProps) {
     const { data, playerStatsMerged, mvp, query } = usePGCRContext()
 
     const stats = playerStatsMerged.get(player.playerInfo.membershipId)!
+    const teamKills = useMemo(
+        () =>
+            playerStatsMerged.reduce((total, playerStats) => total + playerStats.kills, 0),
+        [playerStatsMerged]
+    )
+    const killSharePct =
+        teamKills > 0 ? ((stats.kills + stats.assists) / teamKills) * 100 : 0
     const timePlayed = Math.min(stats.timePlayedSeconds, data.duration)
     const activityPercentage = round(100 * (timePlayed / data.duration), 0)
 
@@ -169,29 +176,33 @@ export default function PlayerRow({ player }: PlayerRowProps) {
                             "text-zinc-500": !player.completed
                         }
                     )}>
-                    {(stats.deaths === 0 ? stats.kills : stats.kills / stats.deaths).toFixed(2)}
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <span>{killSharePct.toFixed(1)}%</span>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            Kill share: (kills + assists) / team kills
+                        </TooltipContent>
+                    </Tooltip>
                 </div>
                 <div
-                    className={cn("text-primary/85 text-center", {
+                    className={cn("text-center", {
                         "text-zinc-500": !player.completed
                     })}>
                     <Tooltip>
                         <TooltipTrigger asChild>
-                            <div className="flex items-center justify-center">
-                                <ActivityPieChart
-                                    percentage={activityPercentage}
-                                    size={16}
-                                    color={player.completed ? "green" : "orange"}
-                                    className="hidden md:block"
-                                />
+                            <div className="flex flex-col items-center gap-0.5">
                                 <span
                                     className={cn(
-                                        "text-primary/85 ml-2 text-xs md:text-sm lg:text-lg",
+                                        "text-primary/85 tabular-nums text-xs md:text-sm lg:text-lg",
                                         {
                                             "text-zinc-500": !player.completed
                                         }
                                     )}>
                                     {secondsToHMS(timePlayed, false)}
+                                </span>
+                                <span className="text-[10px] tabular-nums text-zinc-500">
+                                    {activityPercentage}%
                                 </span>
                             </div>
                         </TooltipTrigger>

--- a/src/components/pgcr/player-row.tsx
+++ b/src/components/pgcr/player-row.tsx
@@ -178,7 +178,10 @@ export default function PlayerRow({ player }: PlayerRowProps) {
                         <TooltipTrigger asChild>
                             <span>{killSharePct.toFixed(1)}%</span>
                         </TooltipTrigger>
-                        <TooltipContent>Kill share: (kills + assists) / team kills</TooltipContent>
+                        <TooltipContent>
+                            (Kills + assists) / team kills. Participation rate, not a share that
+                            sums to 100%.
+                        </TooltipContent>
                     </Tooltip>
                 </div>
                 <div

--- a/src/components/pgcr/player-row.tsx
+++ b/src/components/pgcr/player-row.tsx
@@ -1,8 +1,8 @@
 "use client"
 
-import { useMemo } from "react"
 import { ChevronRight, SquareArrowLeft } from "lucide-react"
 import Link from "next/link"
+import { useMemo } from "react"
 import { useItemDefinition } from "~/hooks/dexie"
 import { usePGCRContext } from "~/hooks/pgcr/ClientStateManager"
 import { useGetCharacterClass } from "~/hooks/pgcr/useCharacterClass"
@@ -25,12 +25,10 @@ export default function PlayerRow({ player }: PlayerRowProps) {
 
     const stats = playerStatsMerged.get(player.playerInfo.membershipId)!
     const teamKills = useMemo(
-        () =>
-            playerStatsMerged.reduce((total, playerStats) => total + playerStats.kills, 0),
+        () => playerStatsMerged.reduce((total, playerStats) => total + playerStats.kills, 0),
         [playerStatsMerged]
     )
-    const killSharePct =
-        teamKills > 0 ? ((stats.kills + stats.assists) / teamKills) * 100 : 0
+    const killSharePct = teamKills > 0 ? ((stats.kills + stats.assists) / teamKills) * 100 : 0
     const timePlayed = Math.min(stats.timePlayedSeconds, data.duration)
     const activityPercentage = round(100 * (timePlayed / data.duration), 0)
 
@@ -180,9 +178,7 @@ export default function PlayerRow({ player }: PlayerRowProps) {
                         <TooltipTrigger asChild>
                             <span>{killSharePct.toFixed(1)}%</span>
                         </TooltipTrigger>
-                        <TooltipContent>
-                            Kill share: (kills + assists) / team kills
-                        </TooltipContent>
+                        <TooltipContent>Kill share: (kills + assists) / team kills</TooltipContent>
                     </Tooltip>
                 </div>
                 <div
@@ -194,14 +190,14 @@ export default function PlayerRow({ player }: PlayerRowProps) {
                             <div className="flex flex-col items-center gap-0.5">
                                 <span
                                     className={cn(
-                                        "text-primary/85 tabular-nums text-xs md:text-sm lg:text-lg",
+                                        "text-primary/85 text-xs tabular-nums md:text-sm lg:text-lg",
                                         {
                                             "text-zinc-500": !player.completed
                                         }
                                     )}>
                                     {secondsToHMS(timePlayed, false)}
                                 </span>
-                                <span className="text-[10px] tabular-nums text-zinc-500">
+                                <span className="text-[10px] text-zinc-500 tabular-nums">
                                     {activityPercentage}%
                                 </span>
                             </div>


### PR DESCRIPTION
## Summary
- Replace the generic Activity Highlights / Combat Stats cards with a unified team summary: MVP banner plus aligned columns for kills, deaths, assists, K/D, melee, grenade, and super kills.
- Swap K/D for kill share in the player summary table and simplify time display (duration + activity %, no pie chart).
- Flatten the weapons section to match: slot columns, compact rows, no nested cards or progress bars.

## Test plan
- [ ] Open a multi-player PGCR and verify MVP banner, team columns, and leader rows align
- [ ] Confirm player table shows kill share % and time with activity % subtext
- [ ] Check weapons section for kinetic/energy/power columns with kills and share %
- [ ] Open single-player detail panel weapons view (precision % subtext)


Made with [Cursor](https://cursor.com)