### PR TITLE
Add Gauntlet Race placement badges for pantheon and PGCR

### DIFF
--- a/src/app/leaderboards/team/custom/pantheon-community-race/page.tsx
+++ b/src/app/leaderboards/team/custom/pantheon-community-race/page.tsx
@@ -22,8 +22,8 @@ export async function generateMetadata(): Promise<Metadata> {
         notFound()
     }
 
-    const title = `${activity.name}: ${version.name} Community Race Leaderboard`
-    const description = `View community race placements for ${version.name} in ${activity.name}`
+    const title = `${activity.name}: ${version.name} Gauntlet Race Leaderboard`
+    const description = `View gauntlet race placements for ${version.name} in ${activity.name}`
 
     return {
         title,
@@ -31,7 +31,7 @@ export async function generateMetadata(): Promise<Metadata> {
         keywords: [
             activity.name,
             version.name,
-            "community race",
+            "gauntlet race",
             "pantheon",
             ...baseMetadata.keywords
         ],
@@ -59,7 +59,7 @@ export default async function Page({ searchParams }: { searchParams: Record<stri
                 <Splash
                     tertiaryTitle={activity.name}
                     title={version.name}
-                    subtitle="Community Race Leaderboard">
+                    subtitle="Gauntlet Race Leaderboard">
                     <CloudflareActivitySplash
                         activityId={version.associatedActivityId}
                         versionId={version.id}

--- a/src/app/pgcr/[instanceId]/opengraph-image.tsx
+++ b/src/app/pgcr/[instanceId]/opengraph-image.tsx
@@ -2,6 +2,7 @@
 import { notFound } from "next/navigation"
 import { ImageResponse } from "next/og"
 import { FallbackSplash } from "~/components/CloudflareImage"
+import { formatLeaderboardRaceLabel } from "~/lib/pgcr/leaderboard-tag"
 import { getMetaData, prefetchActivity } from "~/lib/pgcr/server"
 import { type PGCRPageProps } from "~/lib/pgcr/types"
 import { saferFetch } from "~/lib/server/saferFetch"
@@ -30,6 +31,18 @@ export default async function Image({ params: { instanceId } }: PGCRPageProps) {
     }
 
     const { ogTitle, dateString } = getMetaData(activity)
+    const raceLabel = formatLeaderboardRaceLabel(
+        {
+            isGauntletRace: activity.isGauntletRace,
+            isDayOne: activity.isDayOne,
+            isContest: activity.isContest,
+            isPantheon: activity.isPantheon,
+            versionId: activity.versionId,
+            leaderboardRank: activity.leaderboardRank,
+            versionName: activity.metadata.versionName
+        },
+        versionId => manifest.versionDefinitions[versionId]?.isChallengeMode ?? false
+    )
     const imageVariants = manifest.splashUrls[activity.activityId]
     const backgroundImageUrl =
         imageVariants?.find(v => v.size === "medium")?.url ??
@@ -225,7 +238,7 @@ export default async function Image({ params: { instanceId } }: PGCRPageProps) {
                         justifyContent: "center",
                         alignItems: "center"
                     }}>
-                    {activity.leaderboardRank && (
+                    {raceLabel && (
                         <div
                             style={{
                                 backgroundColor: "rgb(201, 125, 2)",
@@ -233,7 +246,7 @@ export default async function Image({ params: { instanceId } }: PGCRPageProps) {
                                 padding: 4,
                                 borderRadius: 4
                             }}>
-                            {activity.metadata.versionName + " #" + activity.leaderboardRank}
+                            {raceLabel}
                         </div>
                     )}
                 </div>

--- a/src/app/pgcr/[instanceId]/server.ts
+++ b/src/app/pgcr/[instanceId]/server.ts
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation"
+import { formatLeaderboardRaceLabel } from "~/lib/pgcr/leaderboard-tag"
 import { getPgcrShortActivityName } from "~/lib/pgcr/formatting"
 import { Tag } from "~/models/tag"
 import { RaidHubError } from "~/services/raidhub/RaidHubError"
@@ -48,7 +49,21 @@ export const getMetaData = (activity: RaidHubInstanceExtended) => {
             : "completed on"
         : "attempted on"
 
-    const placementSuffix = activity.leaderboardRank ? `#${activity.leaderboardRank}` : null
+    const raceLabel = formatLeaderboardRaceLabel(
+        {
+            isGauntletRace: activity.isGauntletRace,
+            isDayOne: activity.isDayOne,
+            isContest: activity.isContest,
+            isPantheon: activity.isPantheon,
+            versionId: activity.versionId,
+            leaderboardRank: activity.leaderboardRank,
+            versionName: activity.metadata.versionName
+        },
+        () => false
+    )
+
+    const placementSuffix =
+        raceLabel ?? (activity.leaderboardRank ? `#${activity.leaderboardRank}` : null)
 
     const dateCompleted = new Date(activity.dateCompleted)
 

--- a/src/app/pgcr/[instanceId]/server.ts
+++ b/src/app/pgcr/[instanceId]/server.ts
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation"
-import { formatLeaderboardRaceLabel } from "~/lib/pgcr/leaderboard-tag"
 import { getPgcrShortActivityName } from "~/lib/pgcr/formatting"
+import { formatLeaderboardRaceLabel } from "~/lib/pgcr/leaderboard-tag"
 import { Tag } from "~/models/tag"
 import { RaidHubError } from "~/services/raidhub/RaidHubError"
 import { getRaidHubApi } from "~/services/raidhub/common"

--- a/src/components/__deprecated__/profile/raids/RaceTagLabel.tsx
+++ b/src/components/__deprecated__/profile/raids/RaceTagLabel.tsx
@@ -7,6 +7,8 @@ import styles from "./raids.module.css"
 /** @deprecated */
 const RaceTagLabel = ({
     rank,
+    isGauntletRace,
+    versionLabel,
     isChallenge,
     isDayOne,
     isContest,
@@ -16,6 +18,8 @@ const RaceTagLabel = ({
 }: {
     rank: number | null
     instanceId: string
+    isGauntletRace?: boolean
+    versionLabel?: string | null
     isChallenge: boolean
     isDayOne: boolean
     isContest: boolean
@@ -24,6 +28,8 @@ const RaceTagLabel = ({
 }) => {
     const label = useRaceLabel({
         rank,
+        isGauntletRace,
+        versionLabel,
         isChallenge,
         isDayOne,
         isContest,
@@ -49,13 +55,17 @@ const RaceTagLabel = ({
 
 const useRaceLabel = (props: {
     rank: number | null
+    isGauntletRace?: boolean
+    versionLabel?: string | null
     isChallenge: boolean
     isDayOne: boolean
     isContest: boolean
     isWeekOne: boolean
 }): string | null => {
     const tag = useMemo(() => {
-        if (props.isChallenge) {
+        if (props.isGauntletRace) {
+            return Tag.GAUNTLET_RACE
+        } else if (props.isChallenge) {
             return Tag.CHALLENGE
         } else if (props.isDayOne) {
             return Tag.DAY_ONE
@@ -63,10 +73,19 @@ const useRaceLabel = (props: {
             return Tag.CONTEST
         } else if (props.isWeekOne) {
             return Tag.WEEK_ONE
+        } else if (props.versionLabel) {
+            return props.versionLabel
         } else {
             return null
         }
-    }, [props.isChallenge, props.isDayOne, props.isContest, props.isWeekOne])
+    }, [
+        props.isGauntletRace,
+        props.versionLabel,
+        props.isChallenge,
+        props.isDayOne,
+        props.isContest,
+        props.isWeekOne
+    ])
 
     if (tag) {
         return `${tag}${props.rank ? ` #${props.rank}` : ""}`

--- a/src/components/__deprecated__/profile/raids/RaidCard.tsx
+++ b/src/components/__deprecated__/profile/raids/RaidCard.tsx
@@ -27,7 +27,12 @@ export default function RaidCard({
     leaderboardEntry,
     isExpanded
 }: {
-    leaderboardEntry: RaidHubWorldFirstEntry | null
+    leaderboardEntry:
+        | (Omit<RaidHubWorldFirstEntry, "rank"> & {
+              rank: number | null
+              versionLabel?: string | null
+          })
+        | null
     isExpanded?: boolean
 }) {
     const { activities, isLoadingActivities, raidId, versionId } = useRaidCardContext()
@@ -90,6 +95,7 @@ export default function RaidCard({
 
         return {
             instanceId: instance.instanceId,
+            isGauntletRace: false,
             isDayOne: instance.isDayOne,
             isWeekOne: instance.isWeekOne,
             isContest: instance.isContest,
@@ -173,6 +179,12 @@ export default function RaidCard({
                         <RaceTagLabel
                             rank={firstContestClear.rank}
                             instanceId={firstContestClear.instanceId}
+                            isGauntletRace={firstContestClear.isGauntletRace}
+                            versionLabel={
+                                "versionLabel" in firstContestClear
+                                    ? firstContestClear.versionLabel
+                                    : null
+                            }
                             isChallenge={firstContestClear.isChallengeMode}
                             isDayOne={firstContestClear.isDayOne}
                             isContest={firstContestClear.isContest}

--- a/src/components/home/HomeBuckets.tsx
+++ b/src/components/home/HomeBuckets.tsx
@@ -210,7 +210,7 @@ function RaidCard({ raid }: { raid: RaidHubActivityDefinition }) {
 
 const PANTHEON_COMMUNITY_RACE_LINK: LinkItem = {
     href: "/leaderboards/team/custom/pantheon-community-race",
-    label: "Community Race",
+    label: "Gauntlet Race",
     accent: "gold"
 }
 

--- a/src/components/pgcr/pgcr-tags.tsx
+++ b/src/components/pgcr/pgcr-tags.tsx
@@ -9,13 +9,13 @@ export const PGCRTags = () => {
     return (
         !!tags.length && (
             <div className="flex gap-1 md:gap-2">
-                {tags.map(({ tag, placement }) => (
+                {tags.map(({ tag, placement, key }) => (
                     <Badge
-                        key={tag}
+                        key={key}
                         variant="secondary"
                         className="bg-raidhub/90 text-sm text-gray-200">
                         {tag}
-                        {placement && (
+                        {placement != null && (
                             <span className="text text-foreground text-sm font-medium">{` #${placement}`}</span>
                         )}
                     </Badge>

--- a/src/components/profile/raids/PantheonLayout.tsx
+++ b/src/components/profile/raids/PantheonLayout.tsx
@@ -38,8 +38,7 @@ const toPantheonVersionFirstLeaderboardEntry = (
     activityId,
     instanceId: entry.instanceId,
     timeAfterLaunch: 0,
-    rank:
-        entry.isDayOne && suppressesDayOnePlacement(entry.versionId) ? null : entry.rank,
+    rank: entry.isDayOne && suppressesDayOnePlacement(entry.versionId) ? null : entry.rank,
     isDayOne: entry.isDayOne,
     isContest: false,
     isWeekOne: false,
@@ -54,10 +53,12 @@ const resolvePantheonLeaderboardEntry = (
     gauntletRaceEntry: RaidHubGauntletRaceEntry | null,
     pantheonVersionFirstEntries: Collection<number, RaidHubPantheonVersionFirstEntry>,
     getVersionString: (versionId: number) => string
-): (Omit<RaidHubWorldFirstEntry, "rank"> & {
-    rank: number | null
-    versionLabel?: string | null
-}) | null => {
+):
+    | (Omit<RaidHubWorldFirstEntry, "rank"> & {
+          rank: number | null
+          versionLabel?: string | null
+      })
+    | null => {
     const versionFirst = pantheonVersionFirstEntries.get(mode) ?? null
     const gauntlet = gauntletRaceEntry?.versionId === mode ? gauntletRaceEntry : null
 

--- a/src/components/profile/raids/PantheonLayout.tsx
+++ b/src/components/profile/raids/PantheonLayout.tsx
@@ -3,21 +3,97 @@ import { useCallback, useMemo } from "react"
 import { Grid } from "~/components/__deprecated__/layout/Grid"
 import RaidCard from "~/components/__deprecated__/profile/raids/RaidCard"
 import { useRaidHubManifest } from "~/components/providers/RaidHubManifestManager"
-import { type RaidHubInstanceForPlayer } from "~/services/raidhub/types"
+import { suppressesDayOnePlacement } from "~/lib/pgcr/leaderboard-tag"
+import {
+    type RaidHubGauntletRaceEntry,
+    type RaidHubInstanceForPlayer,
+    type RaidHubPantheonVersionFirstEntry,
+    type RaidHubWorldFirstEntry
+} from "~/services/raidhub/types"
 import { RaidCardContext } from "./RaidCardContext"
+
+const toGauntletRaceLeaderboardEntry = (
+    entry: RaidHubGauntletRaceEntry,
+    activityId: number
+): RaidHubWorldFirstEntry => ({
+    activityId,
+    instanceId: entry.instanceId,
+    timeAfterLaunch: 0,
+    rank: entry.rank,
+    isDayOne: false,
+    isContest: false,
+    isWeekOne: false,
+    isChallengeMode: false,
+    isGauntletRace: true
+})
+
+const toPantheonVersionFirstLeaderboardEntry = (
+    entry: RaidHubPantheonVersionFirstEntry,
+    activityId: number,
+    versionLabel: string
+): Omit<RaidHubWorldFirstEntry, "rank"> & {
+    rank: number | null
+    versionLabel?: string | null
+} => ({
+    activityId,
+    instanceId: entry.instanceId,
+    timeAfterLaunch: 0,
+    rank:
+        entry.isDayOne && suppressesDayOnePlacement(entry.versionId) ? null : entry.rank,
+    isDayOne: entry.isDayOne,
+    isContest: false,
+    isWeekOne: false,
+    isChallengeMode: false,
+    isGauntletRace: false,
+    versionLabel: entry.isDayOne ? null : versionLabel
+})
+
+const resolvePantheonLeaderboardEntry = (
+    mode: number,
+    activityId: number,
+    gauntletRaceEntry: RaidHubGauntletRaceEntry | null,
+    pantheonVersionFirstEntries: Collection<number, RaidHubPantheonVersionFirstEntry>,
+    getVersionString: (versionId: number) => string
+): (Omit<RaidHubWorldFirstEntry, "rank"> & {
+    rank: number | null
+    versionLabel?: string | null
+}) | null => {
+    const versionFirst = pantheonVersionFirstEntries.get(mode) ?? null
+    const gauntlet = gauntletRaceEntry?.versionId === mode ? gauntletRaceEntry : null
+
+    if (gauntlet) {
+        return toGauntletRaceLeaderboardEntry(gauntlet, activityId)
+    }
+
+    if (versionFirst) {
+        return toPantheonVersionFirstLeaderboardEntry(
+            versionFirst,
+            activityId,
+            getVersionString(mode)
+        )
+    }
+
+    return null
+}
 
 const PantheonModeGrid = ({
     modes,
     instancesByMode,
     isLoading,
     isExpanded,
-    getActivityIdForVersion
+    getActivityIdForVersion,
+    gauntletRaceEntry,
+    pantheonVersionFirstEntries,
+    getVersionString
 }: {
     modes: readonly number[]
     instancesByMode: Collection<number, Collection<string, RaidHubInstanceForPlayer>> | null
     isLoading: boolean
     isExpanded: boolean
     getActivityIdForVersion: (versionId: number) => number
+    gauntletRaceEntry: RaidHubGauntletRaceEntry | null
+    pantheonVersionFirstEntries: Collection<number, RaidHubPantheonVersionFirstEntry>
+    getVersionString: (versionId: number) => string
 }) => (
     <Grid as="section" $minCardWidth={325} $minCardWidthMobile={300} $fullWidth $relative>
         {modes
@@ -29,7 +105,16 @@ const PantheonModeGrid = ({
                     isLoadingActivities={isLoading}
                     raidId={getActivityIdForVersion(mode)}
                     versionId={mode}>
-                    <RaidCard leaderboardEntry={null} isExpanded={isExpanded} />
+                    <RaidCard
+                        leaderboardEntry={resolvePantheonLeaderboardEntry(
+                            mode,
+                            getActivityIdForVersion(mode),
+                            gauntletRaceEntry,
+                            pantheonVersionFirstEntries,
+                            getVersionString
+                        )}
+                        isExpanded={isExpanded}
+                    />
                 </RaidCardContext>
             ))}
     </Grid>
@@ -38,17 +123,22 @@ const PantheonModeGrid = ({
 export const PantheonLayout = ({
     instances,
     isLoading,
-    isExpanded
+    isExpanded,
+    gauntletRaceEntry,
+    pantheonVersionFirstEntries
 }: {
     instances: Collection<string, RaidHubInstanceForPlayer>[]
     isExpanded: boolean
     isLoading: boolean
+    gauntletRaceEntry: RaidHubGauntletRaceEntry | null
+    pantheonVersionFirstEntries: Collection<number, RaidHubPantheonVersionFirstEntry>
 }) => {
     const {
         activePantheonVersions,
         pantheonSunsetVersions,
         versionDefinitions,
-        activePantheonIds
+        activePantheonIds,
+        getVersionString
     } = useRaidHubManifest()
 
     const getActivityIdForVersion = useCallback(
@@ -78,6 +168,9 @@ export const PantheonLayout = ({
                 isLoading={isLoading}
                 isExpanded={isExpanded}
                 getActivityIdForVersion={getActivityIdForVersion}
+                gauntletRaceEntry={gauntletRaceEntry}
+                pantheonVersionFirstEntries={pantheonVersionFirstEntries}
+                getVersionString={getVersionString}
             />
             {pantheonSunsetVersions.length > 0 && (
                 <div>
@@ -90,6 +183,9 @@ export const PantheonLayout = ({
                         isLoading={isLoading}
                         isExpanded={isExpanded}
                         getActivityIdForVersion={getActivityIdForVersion}
+                        gauntletRaceEntry={gauntletRaceEntry}
+                        pantheonVersionFirstEntries={pantheonVersionFirstEntries}
+                        getVersionString={getVersionString}
                     />
                 </div>
             )}

--- a/src/components/profile/raids/RaidsWrapper.tsx
+++ b/src/components/profile/raids/RaidsWrapper.tsx
@@ -20,7 +20,9 @@ import { useLinkedProfiles } from "~/services/bungie/hooks"
 import { RaidHubError } from "~/services/raidhub/RaidHubError"
 import { useRaidHubActivities, useRaidHubPlayers } from "~/services/raidhub/hooks"
 import {
+    type RaidHubGauntletRaceEntry,
     type RaidHubInstanceForPlayer,
+    type RaidHubPantheonVersionFirstEntry,
     type RaidHubWorldFirstEntry
 } from "~/services/raidhub/types"
 import { ActivityHistoryLayout } from "./ActivityHistoryLayout"
@@ -96,6 +98,36 @@ export const RaidsWrapper = () => {
         return raidToData
     }, [listedRaidIds, players])
 
+    const gauntletRaceEntry = useMemo(() => {
+        let best: RaidHubGauntletRaceEntry | null = null
+
+        players.forEach(p => {
+            const entry = p.gauntletRaceEntry
+            if (!entry) return
+            if (!best || entry.rank < best.rank) {
+                best = entry
+            }
+        })
+
+        return best
+    }, [players])
+
+    const pantheonVersionFirstEntries = useMemo(() => {
+        const entries = new Collection<number, RaidHubPantheonVersionFirstEntry>()
+
+        players.forEach(p => {
+            Object.values(p.pantheonVersionFirstEntries ?? {}).forEach(entry => {
+                if (!entry) return
+                const curr = entries.get(entry.versionId)
+                if (!curr || entry.rank < curr.rank) {
+                    entries.set(entry.versionId, entry)
+                }
+            })
+        })
+
+        return entries
+    }, [players])
+
     const activitiesByRaid = useMemo(() => {
         if (isLoadingActivities) return null
 
@@ -156,6 +188,8 @@ export const RaidsWrapper = () => {
                         )}
                         isLoading={isLoadingActivities || !areMembershipsFetched}
                         isExpanded={isExpanded}
+                        gauntletRaceEntry={gauntletRaceEntry}
+                        pantheonVersionFirstEntries={pantheonVersionFirstEntries}
                     />
                 )
             case "history":
@@ -181,6 +215,8 @@ export const RaidsWrapper = () => {
         activities,
         activitiesByRaid,
         leaderboardEntriesByRaid,
+        gauntletRaceEntry,
+        pantheonVersionFirstEntries,
         isExpanded
     ])
 

--- a/src/hooks/pgcr/usePGCRTags.ts
+++ b/src/hooks/pgcr/usePGCRTags.ts
@@ -1,5 +1,6 @@
 import { useMemo } from "react"
 import { useRaidHubManifest } from "~/components/providers/RaidHubManifestManager"
+import { getLeaderboardRaceBadges } from "~/lib/pgcr/leaderboard-tag"
 import { Tag } from "~/models/tag"
 import { usePGCRContext } from "./ClientStateManager"
 
@@ -10,22 +11,32 @@ export const usePGCRTags = () => {
     return useMemo(() => {
         if (!activity) return []
 
-        const tags = new Array<{ tag: Tag; placement?: number | null }>()
-        if (isChallengeMode(activity.versionId)) {
+        const tags = new Array<{ tag: Tag | string; placement?: number | null; key: string }>()
+
+        getLeaderboardRaceBadges(
+            {
+                isGauntletRace: activity.isGauntletRace,
+                isDayOne: activity.isDayOne,
+                isContest: activity.isContest,
+                isPantheon: activity.isPantheon,
+                versionId: activity.versionId,
+                leaderboardRank: activity.leaderboardRank,
+                versionName: activity.metadata.versionName
+            },
+            isChallengeMode
+        ).forEach(badge => {
             tags.push({
-                tag: Tag.CHALLENGE,
-                placement: activity.leaderboardRank
+                tag: badge.label,
+                placement: badge.placement,
+                key: badge.key
             })
-        } else if (activity.isDayOne) {
-            tags.push({ tag: Tag.DAY_ONE, placement: activity.leaderboardRank })
-        } else if (activity.isContest && !!activity.leaderboardRank) {
-            tags.push({ tag: Tag.CONTEST, placement: activity.leaderboardRank })
-        }
-        if (activity.playerCount === 1) tags.push({ tag: Tag.SOLO })
-        else if (activity.playerCount === 2) tags.push({ tag: Tag.DUO })
-        else if (activity.playerCount === 3) tags.push({ tag: Tag.TRIO })
-        if (activity.flawless) tags.push({ tag: Tag.FLAWLESS })
-        if (selectedFeats.length === feats.length) tags.push({ tag: Tag.ALL_FEATS })
+        })
+
+        if (activity.playerCount === 1) tags.push({ tag: Tag.SOLO, key: "solo" })
+        else if (activity.playerCount === 2) tags.push({ tag: Tag.DUO, key: "duo" })
+        else if (activity.playerCount === 3) tags.push({ tag: Tag.TRIO, key: "trio" })
+        if (activity.flawless) tags.push({ tag: Tag.FLAWLESS, key: "flawless" })
+        if (selectedFeats.length === feats.length) tags.push({ tag: Tag.ALL_FEATS, key: "all-feats" })
 
         return tags
     }, [activity, feats, selectedFeats, isChallengeMode])

--- a/src/hooks/pgcr/usePGCRTags.ts
+++ b/src/hooks/pgcr/usePGCRTags.ts
@@ -36,7 +36,8 @@ export const usePGCRTags = () => {
         else if (activity.playerCount === 2) tags.push({ tag: Tag.DUO, key: "duo" })
         else if (activity.playerCount === 3) tags.push({ tag: Tag.TRIO, key: "trio" })
         if (activity.flawless) tags.push({ tag: Tag.FLAWLESS, key: "flawless" })
-        if (selectedFeats.length === feats.length) tags.push({ tag: Tag.ALL_FEATS, key: "all-feats" })
+        if (selectedFeats.length === feats.length)
+            tags.push({ tag: Tag.ALL_FEATS, key: "all-feats" })
 
         return tags
     }, [activity, feats, selectedFeats, isChallengeMode])

--- a/src/lib/pgcr/leaderboard-tag.ts
+++ b/src/lib/pgcr/leaderboard-tag.ts
@@ -1,0 +1,96 @@
+import { PANTHEON_COMMUNITY_RACE_VERSION_ID } from "~/lib/manifest/pantheon"
+import { Tag } from "~/models/tag"
+
+type LeaderboardTagActivity = {
+    isGauntletRace?: boolean
+    isDayOne?: boolean
+    isContest?: boolean
+    isPantheon?: boolean
+    versionId?: number
+    leaderboardRank?: number | null
+    versionName?: string
+}
+
+export type LeaderboardRaceBadge = {
+    label: string
+    placement?: number | null
+    key: string
+}
+
+/** Insurrection Prime Revolutionary — version-first rank is never shown as a Day One #. */
+export const suppressesDayOnePlacement = (versionId?: number) =>
+    versionId === PANTHEON_COMMUNITY_RACE_VERSION_ID
+
+export const getLeaderboardRaceBadges = (
+    activity: LeaderboardTagActivity,
+    isChallengeMode: (versionId: number) => boolean
+): LeaderboardRaceBadge[] => {
+    const badges: LeaderboardRaceBadge[] = []
+    const rank = activity.leaderboardRank
+
+    if (activity.isGauntletRace && rank) {
+        return [
+            {
+                label: Tag.GAUNTLET_RACE,
+                placement: rank,
+                key: "gauntlet-race"
+            }
+        ]
+    }
+
+    if (activity.isDayOne) {
+        badges.push({
+            label: Tag.DAY_ONE,
+            placement: suppressesDayOnePlacement(activity.versionId) ? null : rank,
+            key: "day-one"
+        })
+        return badges
+    }
+
+    if (!rank) {
+        return badges
+    }
+
+    if (activity.versionId != null && isChallengeMode(activity.versionId)) {
+        badges.push({
+            label: Tag.CHALLENGE,
+            placement: rank,
+            key: "challenge"
+        })
+    } else if (activity.isContest) {
+        badges.push({
+            label: Tag.CONTEST,
+            placement: rank,
+            key: "contest"
+        })
+    } else if (activity.isPantheon && activity.versionName) {
+        badges.push({
+            label: activity.versionName,
+            placement: rank,
+            key: `pantheon-${activity.versionId ?? activity.versionName}`
+        })
+    }
+
+    return badges
+}
+
+/** Primary labeled badge for OG images and metadata (prefers a numeric placement). */
+export const getLeaderboardRaceBadge = (
+    activity: LeaderboardTagActivity,
+    isChallengeMode: (versionId: number) => boolean
+): LeaderboardRaceBadge | null => {
+    const badges = getLeaderboardRaceBadges(activity, isChallengeMode)
+    return badges.find(b => b.placement != null) ?? badges[0] ?? null
+}
+
+export const formatLeaderboardRaceLabel = (
+    activity: LeaderboardTagActivity,
+    isChallengeMode: (versionId: number) => boolean
+): string | null => {
+    const badge = getLeaderboardRaceBadge(activity, isChallengeMode)
+    if (!badge) {
+        return null
+    }
+
+    return badge.placement != null ? `${badge.label} #${badge.placement}` : badge.label
+}

--- a/src/lib/pgcr/server.ts
+++ b/src/lib/pgcr/server.ts
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation"
+import { formatLeaderboardRaceLabel } from "~/lib/pgcr/leaderboard-tag"
 import { getPgcrShortActivityName } from "~/lib/pgcr/formatting"
 import { Tag } from "~/models/tag"
 import { RaidHubError } from "~/services/raidhub/RaidHubError"
@@ -48,7 +49,21 @@ export const getMetaData = (activity: RaidHubInstanceExtended) => {
             : "completed on"
         : "attempted on"
 
-    const placementSuffix = activity.leaderboardRank ? `#${activity.leaderboardRank}` : null
+    const raceLabel = formatLeaderboardRaceLabel(
+        {
+            isGauntletRace: activity.isGauntletRace,
+            isDayOne: activity.isDayOne,
+            isContest: activity.isContest,
+            isPantheon: activity.isPantheon,
+            versionId: activity.versionId,
+            leaderboardRank: activity.leaderboardRank,
+            versionName: activity.metadata.versionName
+        },
+        () => false
+    )
+
+    const placementSuffix =
+        raceLabel ?? (activity.leaderboardRank ? `#${activity.leaderboardRank}` : null)
 
     const dateCompleted = new Date(activity.dateCompleted)
 

--- a/src/lib/pgcr/server.ts
+++ b/src/lib/pgcr/server.ts
@@ -1,6 +1,6 @@
 import { notFound } from "next/navigation"
-import { formatLeaderboardRaceLabel } from "~/lib/pgcr/leaderboard-tag"
 import { getPgcrShortActivityName } from "~/lib/pgcr/formatting"
+import { formatLeaderboardRaceLabel } from "~/lib/pgcr/leaderboard-tag"
 import { Tag } from "~/models/tag"
 import { RaidHubError } from "~/services/raidhub/RaidHubError"
 import { getRaidHubApi } from "~/services/raidhub/common"

--- a/src/models/tag.ts
+++ b/src/models/tag.ts
@@ -5,6 +5,7 @@ export enum Tag {
     TRIO = "Trio",
     CHALLENGE = "Challenge",
     DAY_ONE = "Day One",
+    GAUNTLET_RACE = "Gauntlet Race",
     CONTEST = "Contest",
     WEEK_ONE = "Week One",
     MASTER = "Master",

--- a/src/services/raidhub/openapi.d.ts
+++ b/src/services/raidhub/openapi.d.ts
@@ -2855,12 +2855,14 @@ export interface components {
       readonly platformType: components["schemas"]["DestinyMembershipType"];
       readonly activityId: number;
       readonly versionId: number;
-      /** @description If the instance was completed before the day one end date */
+      /** @description If the instance was completed within 24 hours of release. For pantheon modes, uses the version release date (release_date_override when set); otherwise uses the activity day_one_end. */
       readonly isDayOne: boolean;
       /** @description If this clear was contest mode: when the activity exposes version_id 32 (contest) on activity_version, true only for that version while still before contest_end; otherwise true when completed before contest_end (legacy raids). */
       readonly isContest: boolean;
       /** @description If the instance was completed before the week one end date */
       readonly isWeekOne: boolean;
+      /** @description If the instance is a pantheon activity mode */
+      readonly isPantheon: boolean;
       /** @description If the instance is blacklisted from leaderboards */
       readonly isBlacklisted: boolean;
     };
@@ -3300,6 +3302,20 @@ export interface components {
       readonly isContest: boolean;
       readonly isWeekOne: boolean;
       readonly isChallengeMode: boolean;
+      readonly isGauntletRace?: boolean;
+    };
+    readonly GauntletRaceEntry: {
+      /** Format: int64 */
+      readonly instanceId: string;
+      readonly rank: number;
+      readonly versionId: number;
+    };
+    readonly PantheonVersionFirstEntry: {
+      readonly versionId: number;
+      /** Format: int64 */
+      readonly instanceId: string;
+      readonly rank: number;
+      readonly isDayOne: boolean;
     };
     readonly Teammate: {
       readonly estimatedTimePlayedSeconds: number;
@@ -3531,6 +3547,10 @@ export interface components {
       readonly worldFirstEntries: {
         [key: string]: components["schemas"]["WorldFirstEntry"];
       };
+      readonly gauntletRaceEntry: components["schemas"]["GauntletRaceEntry"];
+      readonly pantheonVersionFirstEntries: {
+        [key: string]: components["schemas"]["PantheonVersionFirstEntry"];
+      };
     };
     readonly PlayerTeammatesResponse: readonly components["schemas"]["Teammate"][];
     readonly PlayerInstancesResponse: readonly (components["schemas"]["Instance"] & {
@@ -3543,6 +3563,7 @@ export interface components {
     };
     readonly InstanceResponse: components["schemas"]["Instance"] & ({
       readonly leaderboardRank: number | null;
+      readonly isGauntletRace: boolean;
       readonly metadata: components["schemas"]["InstanceMetadata"];
       readonly players: readonly components["schemas"]["InstancePlayerExtended"][];
     });

--- a/src/services/raidhub/types.ts
+++ b/src/services/raidhub/types.ts
@@ -51,6 +51,8 @@ export type RaidHubInstancePlayerExtended = Component<"InstancePlayerExtended">
 export type RaidHubInstanceCharacter = Component<"InstanceCharacter">
 export type RaidHubInstanceForPlayer = Component<"InstanceForPlayer">
 export type RaidHubWorldFirstEntry = Component<"WorldFirstEntry">
+export type RaidHubGauntletRaceEntry = Component<"GauntletRaceEntry">
+export type RaidHubPantheonVersionFirstEntry = Component<"PantheonVersionFirstEntry">
 export type RaidHubClanMemberStats = Component<"ClanMemberStats">
 
 export type RaidHubWeaponMetric = Component<"WeaponMetric">


### PR DESCRIPTION
## Summary
- Add Gauntlet Race badge on PGCR, OG images, and pantheon profile cards when a clear is on the gauntlet race leaderboard
- Show pantheon version-first placement badges (version name + rank) for non-day-one clears
- Gauntlet supersedes Day One when both apply; Insurrection Prime (v134) never shows Day One `#` from version-first rank
- Rename Community Race labels to Gauntlet Race in home buckets and leaderboard page

Depends on API PR merging first (new `isGauntletRace`, `isPantheon`, profile fields).

## Test plan
- [ ] PGCR for gauntlet race clear shows `Gauntlet Race #N` only (not `Day One #N`)
- [ ] PGCR for other pantheon day-one clears shows `Day One #N`
- [ ] Insurrection Prime day-one clear without gauntlet shows `Day One` without number
- [ ] Pantheon profile tab shows golden badge on correct mode cards
- [ ] CI passes


Made with [Cursor](https://cursor.com)