### PR TITLE
Use separate Pantheon 2 splash art on home card

### DIFF
--- a/src/components/CloudflareImage.tsx
+++ b/src/components/CloudflareImage.tsx
@@ -36,7 +36,7 @@ const cloudflareVariants: {
     }
 ]
 
-export const FallbackSplash = "https://cdn.raidhub.io/content/splash/pantheon/large.png"
+export const FallbackSplash = "https://cdn.raidhub.io/content/splash/pantheon/large.jpg"
 
 const CloudflareStaticImages = {
     raidhubCitySplash: {
@@ -68,8 +68,10 @@ const CloudflareStaticImages = {
     genericRaidSplash: {
         path: "splash/pantheon",
         variants: {
-            small: "small.png",
-            large: "large.png"
+            tiny: "tiny.jpg",
+            small: "small.jpg",
+            medium: "medium.jpg",
+            large: "large.jpg"
         }
     },
     ...VaultEmblems,

--- a/src/components/home/HomeBuckets.tsx
+++ b/src/components/home/HomeBuckets.tsx
@@ -228,7 +228,6 @@ function PantheonCard({
     const title =
         (activityId != null ? getActivityDefinition(activityId)?.name : null) ?? "The Pantheon"
     const releaseDate = activityId != null ? getActivityDefinition(activityId)?.releaseDate : null
-    const headerVersionId = versions.length > 0 ? Math.max(...versions) : null
 
     const versionGroups = useMemo(
         () =>
@@ -265,7 +264,6 @@ function PantheonCard({
             <SplashHeader
                 title={title}
                 activityId={activityId}
-                versionId={headerVersionId}
                 releaseDate={releaseDate}
                 expanded={expanded}
                 onToggle={() => setExpanded(e => !e)}


### PR DESCRIPTION
## Summary
- Use activity-level splash for the Pantheon home card instead of a version boss image
- Point generic fallbacks at restored Pantheon 1 JPG assets on CDN
- Activity 102 picks up `pantheon2` splash once manifest/API seed is updated

## Test plan
- [ ] Home Pantheon card shows Monument of Triumph art after prod DB update
- [ ] Sunset Pantheon card still shows Into the Light art
- [ ] Fallback splash URLs resolve on CDN


Made with [Cursor](https://cursor.com)