### PR TITLE
fix(pgcr): use version splashes only for Pantheon modes

### DIFF
--- a/src/components/pgcr/pgcr-header-bg.tsx
+++ b/src/components/pgcr/pgcr-header-bg.tsx
@@ -9,17 +9,19 @@ export const PGCRHeaderBackground = ({
     children
 }: {
     activityId: number
-    versionId?: number
+    versionId: number
     children: React.ReactNode
 }) => {
-    const { getImageVariantsForActivity, getImageVariantsForVersion } = useRaidHubManifest()
-    const imageVariants =
-        versionId != null
-            ? getImageVariantsForVersion(versionId)
-            : getImageVariantsForActivity(activityId)
-    const variant = imageVariants.find(v => v.size === "small") ?? imageVariants[0]
+    const { getImageVariantsForActivity, getImageVariantsForVersion, pantheonVersions } =
+        useRaidHubManifest()
 
+    const imageVariants = pantheonVersions.includes(versionId)
+        ? getImageVariantsForVersion(versionId)
+        : getImageVariantsForActivity(activityId)
+
+    const variant = imageVariants.find(v => v.size === "small") ?? imageVariants[0]
     const backgroundImageUrl = variant?.url ?? FallbackSplash
+
     return (
         <div
             className="relative min-h-44 rounded-t-lg bg-cover bg-center md:min-h-48"

--- a/src/components/providers/RaidHubManifestManager.tsx
+++ b/src/components/providers/RaidHubManifestManager.tsx
@@ -121,7 +121,7 @@ export function RaidHubManifestManager(props: {
                 return variants ?? []
             },
             getImageVariantsForVersion(versionId) {
-                const variants = data.versionSplashUrls[versionId]
+                const variants = data.versionSplashUrls?.[versionId]
                 return variants ?? []
             }
         }


### PR DESCRIPTION
## Summary
- Restrict PGCR header splash lookup to \ersionSplashUrls\ only for Pantheon version IDs
- Keep all other activities (including EDP) on activity-level \splashUrls\, fixing incorrect Pantheon fallback art on raid PGCRs
- Use optional chaining when reading \ersionSplashUrls\ from the manifest

## Test plan
- [ ] Open an EDP Epic PGCR and confirm the header uses the \edp\ splash, not Pantheon
- [ ] Open a normal raid PGCR (e.g. Desert Perpetual Standard) and confirm the correct activity splash
- [ ] Open a Pantheon mode PGCR and confirm it still uses the per-version splash when available


Made with [Cursor](https://cursor.com)