### PR TITLE
Fix profile raid tag labels broken by History tab refactor

### DIFF
--- a/src/components/providers/RaidHubManifestManager.tsx
+++ b/src/components/providers/RaidHubManifestManager.tsx
@@ -38,6 +38,7 @@ type ManifestContextData = RaidHubManifestResponse & {
     findPantheonVersionByPath(versionPath: string): RaidHubVersionDefinition | null
     getActivityDefinition(activityId: number): RaidHubActivityDefinition | null
     isChallengeMode(versionId: number): boolean
+    getCheckpointName(activityId: number): string | null
     getImageVariantsForActivity(activityId: number | string): readonly ImageContentData[]
     getImageVariantsForVersion(versionId: number | string): readonly ImageContentData[]
 }
@@ -115,6 +116,9 @@ export function RaidHubManifestManager(props: {
             },
             isChallengeMode(versionId) {
                 return data.versionDefinitions[versionId]?.isChallengeMode ?? false
+            },
+            getCheckpointName(activityId) {
+                return data.checkpointNames?.[activityId] ?? null
             },
             getImageVariantsForActivity(activityId) {
                 const variants = data.splashUrls[activityId]

--- a/src/hooks/useActivityDisplayParts.ts
+++ b/src/hooks/useActivityDisplayParts.ts
@@ -14,20 +14,22 @@ export const useActivityDisplayParts = (
         pantheonTitleStyle?: "boss" | "full"
     }
 ): ActivityDisplayParts | null => {
-    const { getActivityString, getVersionString, pantheonVersions } = useRaidHubManifest()
+    const { getActivityString, getVersionString, getCheckpointName, pantheonVersions } =
+        useRaidHubManifest()
     const { includeFresh, excludeTitle, pantheonTitleStyle } = opts ?? {}
 
     return useMemo(
         () =>
             getActivityDisplayParts(
                 activity,
-                { getActivityString, getVersionString, pantheonVersions },
+                { getActivityString, getVersionString, getCheckpointName, pantheonVersions },
                 { includeFresh, excludeTitle, pantheonTitleStyle }
             ),
         [
             activity,
             excludeTitle,
             getActivityString,
+            getCheckpointName,
             getVersionString,
             includeFresh,
             pantheonTitleStyle,

--- a/src/lib/activity/display.ts
+++ b/src/lib/activity/display.ts
@@ -14,6 +14,7 @@ export type ActivityDisplayInput = {
 export type ActivityDisplayContext = {
     getActivityString: (activityId: number) => string
     getVersionString: (versionId: number) => string
+    getCheckpointName: (activityId: number) => string | null
     pantheonVersions: readonly number[]
 }
 
@@ -23,14 +24,14 @@ export type ActivityDisplayParts = {
     tags: string[]
 }
 
-/** Version-specific labels (Master, Contest, etc.) that belong in the title, not attempt tags. */
+/** Version-specific labels (Challenge, etc.) that belong in the title, not attempt tags. */
 export const getIntrinsicVersionLabel = (
     versionId: number,
     versionName: string,
     isContest: boolean
 ): string | null => {
-    if (isContest && versionName !== Tag.CONTEST) {
-        return Tag.CONTEST
+    if (isContest || versionName === Tag.CONTEST || versionName === Tag.MASTER) {
+        return null
     }
 
     if (versionId === 1 || versionName === "Unknown") {
@@ -81,16 +82,23 @@ export const getActivityDisplayParts = (
         }
     }
 
-    const intrinsicLabel = getIntrinsicVersionLabel(
-        activity.versionId,
-        versionName,
-        activity.isContest
-    )
+    if (versionName === "Master") {
+        tags.push(Tag.MASTER)
+    } else if (activity.isContest) {
+        tags.push(Tag.CONTEST)
+    }
 
     if (wishWall) {
         tags.push("Wish Wall")
     } else if (!activity.fresh && !activity.flawless) {
-        tags.push(Tag.CHECKPOINT)
+        if (activity.completed && activity.playerCount <= 3) {
+            const checkpointName = ctx.getCheckpointName(activity.activityId)
+            if (checkpointName) {
+                tags.push(checkpointName)
+            }
+        } else if (activity.playerCount > 3) {
+            tags.push(Tag.CHECKPOINT)
+        }
     }
 
     if (opts?.excludeTitle) {
@@ -103,9 +111,14 @@ export const getActivityDisplayParts = (
             : versionName
         : activityName
 
-    const versionLabel = intrinsicLabel && !isPantheon ? intrinsicLabel : null
+    const versionLabel = getIntrinsicVersionLabel(
+        activity.versionId,
+        versionName,
+        activity.isContest
+    )
+    const showVersionLabel = versionLabel && !isPantheon ? versionLabel : null
 
-    return { title: baseTitle, versionLabel, tags }
+    return { title: baseTitle, versionLabel: showVersionLabel, tags }
 }
 
 export const formatActivityDisplayParts = ({

--- a/src/services/raidhub/openapi.d.ts
+++ b/src/services/raidhub/openapi.d.ts
@@ -3459,6 +3459,10 @@ export interface components {
       readonly versionSplashUrls: {
         [key: string]: readonly components["schemas"]["ImageContentData"][];
       };
+      /** @description The checkpoint encounter name for each raid activityId, used in lowman tag labels */
+      readonly checkpointNames: {
+        readonly [key: string]: string;
+      };
     };
     readonly StatusResponse: {
       readonly AtlasPGCR: components["schemas"]["AtlasStatus"];


### PR DESCRIPTION
## Summary
- Restore lowman checkpoint tag logic: ≤3 players get boss name from manifest (`Solo Witness`) instead of generic `Checkpoint`
- Move Master/Contest back into tag labels (not title-only), matching pre-#340 behavior
- Wire `getCheckpointName` through manifest provider and activity display helpers

Depends on API PR restoring `checkpointNames` on `/manifest`.

## Test plan
- [x] Lint passes
- [ ] Profile tags on Salvation's Edge show "Solo Witness" / "Duo Master Witness" instead of "Solo Checkpoint"
- [ ] Full-team checkpoint runs still show "Checkpoint"


Made with [Cursor](https://cursor.com)