### PR TITLE
Wrap long version names in profile dot tooltips

### DIFF
--- a/src/components/__deprecated__/profile/raids/DotTooltip.tsx
+++ b/src/components/__deprecated__/profile/raids/DotTooltip.tsx
@@ -3,7 +3,7 @@ import { useRaidHubManifest } from "~/components/providers/RaidHubManifestManage
 import { DotBlacklisted, DotFail, DotFlawless, DotSuccess, DotTaxi } from "~/lib/profile/constants"
 import { Tag } from "~/models/tag"
 import type { RaidHubInstanceForPlayer } from "~/services/raidhub/types"
-import { secondsToHMS } from "~/util/presentation/formatting"
+import { secondsToHMS, wrapText } from "~/util/presentation/formatting"
 import { getRelativeTime } from "~/util/presentation/pastDates"
 import { FULL_HEIGHT } from "./DotGraph"
 import styles from "./raids.module.css"
@@ -23,6 +23,11 @@ const DotTooltip = ({ offset, isShowing, activity }: DotTooltipProps) => {
     const dateString = useMemo(
         () => getRelativeTime(new Date(activity.dateCompleted)),
         [activity.dateCompleted]
+    )
+
+    const versionString = useMemo(
+        () => wrapText(getVersionString(activity.versionId), 18),
+        [activity.versionId, getVersionString]
     )
 
     const lowman = activity.completed
@@ -59,7 +64,7 @@ const DotTooltip = ({ offset, isShowing, activity }: DotTooltipProps) => {
             <div className={styles["dot-tooltip-tags"]}>
                 <span>{lowman}</span>
                 <span>{activity.flawless && Tag.FLAWLESS}</span>
-                <span>{getVersionString(activity.versionId)}</span>
+                <span className={styles["dot-tooltip-wrap"]}>{versionString}</span>
             </div>
         </div>
     )

--- a/src/components/__deprecated__/profile/raids/raids.module.css
+++ b/src/components/__deprecated__/profile/raids/raids.module.css
@@ -244,7 +244,6 @@
 
     font-size: 0.7rem;
     text-align: center;
-    white-space: nowrap;
 
     display: flex;
     flex-direction: column;
@@ -274,6 +273,10 @@
 .dot-tooltip-tags {
     display: flex;
     flex-direction: column;
+}
+
+.dot-tooltip-wrap {
+    white-space: pre-line;
 }
 
 .timings {

--- a/src/util/presentation/formatting.ts
+++ b/src/util/presentation/formatting.ts
@@ -112,6 +112,36 @@ export function secondsToYDHMS(totalSeconds: number, count = 5): string {
     return result.slice(0, count).join(" ")
 }
 
+export function wrapText(text: string, maxChars: number): string {
+    if (text.length <= maxChars) {
+        return text
+    }
+
+    const lines: string[] = []
+    let current = ""
+
+    for (const word of text.split(" ")) {
+        if (!current) {
+            current = word
+            continue
+        }
+
+        const next = `${current} ${word}`
+        if (next.length <= maxChars) {
+            current = next
+        } else {
+            lines.push(current)
+            current = word
+        }
+    }
+
+    if (current) {
+        lines.push(current)
+    }
+
+    return lines.join("\n")
+}
+
 const domParser = typeof window !== "undefined" ? new DOMParser() : null
 export const decodeHtmlEntities = (html: string) => {
     if (typeof window === "undefined") return html


### PR DESCRIPTION
## Summary
- Wrap long activity version names in the profile dot graph tooltip at word boundaries (18 chars)
- Remove `white-space: nowrap` so wrapped lines render correctly

## Test plan
- [x] Hover a Pantheon dot with a long version name (e.g. Insurrection Prime Revolutionary)
- [x] Confirm tooltip stays narrow and version name breaks across lines


Made with [Cursor](https://cursor.com)