### PR TITLE
Fix Finder season cap and display clan ranks

### DIFF
--- a/src/app/clan/StatBox.tsx
+++ b/src/app/clan/StatBox.tsx
@@ -1,15 +1,19 @@
+"use client"
+
 import styled from "styled-components"
 
 export const StatBox = ({
     label,
     primaryValue,
     secondaryValue,
-    aggLabel
+    aggLabel,
+    rank
 }: {
     label: string
     primaryValue: string
     secondaryValue?: string
     aggLabel: string
+    rank?: number
 }) => {
     return (
         <StyledStatBox>
@@ -18,6 +22,7 @@ export const StatBox = ({
                 <div className="stat-box-value">
                     <span>{primaryValue}</span>
                 </div>
+                {rank != null && <div className="stat-box-rank">Rank #{rank}</div>}
                 <div className="stat-box-agg-value">
                     {secondaryValue ? (
                         <>
@@ -53,6 +58,11 @@ const StyledStatBox = styled.div`
 
     .stat-box-value {
         font-size: 1.25rem;
+        color: ${({ theme }) => theme.colors.text.primary};
+    }
+
+    .stat-box-rank {
+        font-size: 0.9em;
         color: ${({ theme }) => theme.colors.text.primary};
     }
 

--- a/src/components/__deprecated__/clan/Clan.tsx
+++ b/src/components/__deprecated__/clan/Clan.tsx
@@ -119,6 +119,7 @@ export function ClanComponent(props: { groupId: string; clan: GroupResponse | nu
     }
 
     const aggStats = clanStatsQuery.data?.aggregateStats.stats
+    const aggRanks = clanStatsQuery.data?.aggregateStats.ranks
     const clanLevelProgression = clan?.detail.clanInfo.d2ClanProgressions[584850370]
 
     return (
@@ -156,6 +157,7 @@ export function ClanComponent(props: { groupId: string; clan: GroupResponse | nu
                                         3
                                     )}
                                     aggLabel="Total"
+                                    rank={aggRanks?.weightedContestScoreRank}
                                 />
                                 <StatBox
                                     label="Full Clears"
@@ -166,6 +168,7 @@ export function ClanComponent(props: { groupId: string; clan: GroupResponse | nu
                                         0
                                     )}
                                     aggLabel="Avg"
+                                    rank={aggRanks?.freshClearsRank}
                                 />
                                 <StatBox
                                     label="Clears"
@@ -176,6 +179,7 @@ export function ClanComponent(props: { groupId: string; clan: GroupResponse | nu
                                         0
                                     )}
                                     aggLabel="Avg"
+                                    rank={aggRanks?.clearsRank}
                                 />
                                 <StatBox
                                     label="Sherpas"
@@ -186,6 +190,7 @@ export function ClanComponent(props: { groupId: string; clan: GroupResponse | nu
                                         0
                                     )}
                                     aggLabel="Avg"
+                                    rank={aggRanks?.sherpasRank}
                                 />
                                 <StatBox
                                     label="Time in Raids"
@@ -195,6 +200,7 @@ export function ClanComponent(props: { groupId: string; clan: GroupResponse | nu
                                         2
                                     )}
                                     aggLabel="Avg"
+                                    rank={aggRanks?.timePlayedSecondsRank}
                                 />
                             </>
                         )}

--- a/src/components/profile/raids/finder/InstanceFinderForm.tsx
+++ b/src/components/profile/raids/finder/InstanceFinderForm.tsx
@@ -132,8 +132,7 @@ export const InstanceFinderForm = ({
 
     const seasonsOptions =
         useSeasons({ reversed: true })
-            ?.filter(s => s.seasonNumber <= 26)
-            .map(season => ({
+            ?.map(season => ({
                 value: season.seasonNumber,
                 label: season.displayProperties.name || "Red War"
             })) ?? []

--- a/src/components/profile/raids/finder/InstanceFinderForm.tsx
+++ b/src/components/profile/raids/finder/InstanceFinderForm.tsx
@@ -131,11 +131,10 @@ export const InstanceFinderForm = ({
     }, [parsedActivityId, form])
 
     const seasonsOptions =
-        useSeasons({ reversed: true })
-            ?.map(season => ({
-                value: season.seasonNumber,
-                label: season.displayProperties.name || "Red War"
-            })) ?? []
+        useSeasons({ reversed: true })?.map(season => ({
+            value: season.seasonNumber,
+            label: season.displayProperties.name || "Red War"
+        })) ?? []
 
     return (
         <FormProvider {...form}>


### PR DESCRIPTION
## Summary
- Remove the hardcoded `seasonNumber <= 26` filter in Instance Finder so seasons 27+ appear in the dropdown (fixes #302)
- Display global clan leaderboard ranks on each stat box on the clan page (fixes #260; API already returns `aggregateStats.ranks`)

## Test plan
- [x] `bun run lint` passes locally
- [x] `tsc --noEmit` passes locally
- [x] `/clan/3148408` loads on local dev (`https://localhost:3000`)
- [ ] Verify Finder season dropdown includes current season on a profile
- [ ] Verify clan stat boxes show `Rank #N` after stats load


Made with [Cursor](https://cursor.com)