### PR TITLE
Fix profile transitory infinite loading skeleton

### DIFF
--- a/src/components/profile/ProfilePage.tsx
+++ b/src/components/profile/ProfilePage.tsx
@@ -1,10 +1,32 @@
-import { Suspense } from "react"
+import { Suspense, type ReactNode } from "react"
 import { Loading } from "~/components/Loading"
 import { Flex } from "~/components/__deprecated__/layout/Flex"
 import { RaidsWrapper } from "./raids/RaidsWrapper"
 import { CurrentActivity } from "./transitory/CurrentActivity"
 import { LatestRaid } from "./transitory/LatestRaid"
 import { UserCard } from "./user/UserCard"
+
+const TransitorySuspense = ({
+    destinyMembershipId,
+    children
+}: {
+    destinyMembershipId: string
+    children: ReactNode
+}) => (
+    <Suspense
+        key={destinyMembershipId}
+        fallback={
+            <Loading
+                $fill
+                $minHeight="250px"
+                $alpha={0.75}
+                $minWidth="200px"
+                style={{ width: "min(100%, 800px)", minHeight: "250px" }}
+            />
+        }>
+        {children}
+    </Suspense>
+)
 
 export const ProfilePage = ({ destinyMembershipId }: { destinyMembershipId: string }) => (
     <Flex $direction="column" $padding={0} $crossAxis="flex-start">
@@ -16,31 +38,23 @@ export const ProfilePage = ({ destinyMembershipId }: { destinyMembershipId: stri
             $fullWidth
             style={{ columnGap: "4rem", maxWidth: "100%" }}>
             <UserCard />
-            <Suspense
-                key={destinyMembershipId}
-                fallback={
-                    <Loading
-                        $fill
-                        $minHeight="250px"
-                        $alpha={0.75}
-                        $minWidth="200px"
-                        style={{ width: "min(100%, 800px)", minHeight: "250px" }}
-                    />
-                }>
-                <Flex
-                    $padding={0}
-                    $direction="row"
-                    $wrap
-                    $align="flex-start"
-                    $crossAxis="stretch"
-                    style={{
-                        flexGrow: 1,
-                        flexBasis: "100%"
-                    }}>
+            <Flex
+                $padding={0}
+                $direction="row"
+                $wrap
+                $align="flex-start"
+                $crossAxis="stretch"
+                style={{
+                    flexGrow: 1,
+                    flexBasis: "100%"
+                }}>
+                <TransitorySuspense destinyMembershipId={destinyMembershipId}>
                     <CurrentActivity />
+                </TransitorySuspense>
+                <TransitorySuspense destinyMembershipId={destinyMembershipId}>
                     <LatestRaid />
-                </Flex>
-            </Suspense>
+                </TransitorySuspense>
+            </Flex>
         </Flex>
         <RaidsWrapper />
     </Flex>

--- a/src/components/profile/transitory/CurrentActivity.tsx
+++ b/src/components/profile/transitory/CurrentActivity.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import type { BungieMembershipType } from "bungie-net-core/models"
 import type {
     DestinyCharacterActivitiesComponent,
     DestinyProfileTransitoryPartyMember
@@ -41,7 +42,7 @@ const defaultCharacterActivity: DestinyCharacterActivitiesComponent = {
 export const CurrentActivity = () => {
     const { destinyMembershipId, destinyMembershipType } = usePageProps<ProfileProps>()
 
-    const { data: profileTransitoryData, isInitialLoading } = useProfileTransitory(
+    const { data: profileTransitoryData } = useProfileTransitory(
         { destinyMembershipId, membershipType: destinyMembershipType },
         {
             select: data => data?.profileTransitoryData.data,
@@ -50,13 +51,32 @@ export const CurrentActivity = () => {
         }
     )
 
+    if (!profileTransitoryData?.currentActivity?.startTime) {
+        return null
+    }
+
+    return (
+        <CurrentActivityLive
+            destinyMembershipId={destinyMembershipId}
+            destinyMembershipType={destinyMembershipType}
+            startTime={new Date(profileTransitoryData.currentActivity.startTime)}
+            partyMembers={profileTransitoryData.partyMembers}
+        />
+    )
+}
+
+const CurrentActivityLive = (props: {
+    destinyMembershipId: string
+    destinyMembershipType: BungieMembershipType
+    startTime: Date
+    partyMembers: DestinyProfileTransitoryPartyMember[]
+}) => {
     const { data: characterActivity } = useProfileLiveData(
         {
-            destinyMembershipId,
-            membershipType: destinyMembershipType
+            destinyMembershipId: props.destinyMembershipId,
+            membershipType: props.destinyMembershipType
         },
         {
-            enabled: isInitialLoading || !!profileTransitoryData?.currentActivity?.startTime,
             suspense: true,
             select: data =>
                 Object.values(data.characterActivities.data ?? {}).sort((a, b) =>
@@ -66,13 +86,17 @@ export const CurrentActivity = () => {
         }
     )
 
-    return profileTransitoryData?.currentActivity?.startTime && characterActivity ? (
+    if (!characterActivity) {
+        return null
+    }
+
+    return (
         <CurrentActivityCard
             characterActivity={characterActivity}
-            startTime={new Date(profileTransitoryData.currentActivity.startTime)}
-            partyMembers={profileTransitoryData.partyMembers}
+            startTime={props.startTime}
+            partyMembers={props.partyMembers}
         />
-    ) : null
+    )
 }
 
 const CurrentActivityCard = (props: {

--- a/src/components/profile/transitory/CurrentActivity.tsx
+++ b/src/components/profile/transitory/CurrentActivity.tsx
@@ -1,7 +1,7 @@
 "use client"
 
-import type { BungieMembershipType } from "bungie-net-core/models"
 import type {
+    BungieMembershipType,
     DestinyCharacterActivitiesComponent,
     DestinyProfileTransitoryPartyMember
 } from "bungie-net-core/models"

--- a/src/components/profile/transitory/LatestRaid.tsx
+++ b/src/components/profile/transitory/LatestRaid.tsx
@@ -21,16 +21,34 @@ import { Latest } from "./Latest"
 
 export const LatestRaid = () => {
     const { destinyMembershipId } = usePageProps<ProfileProps>()
-    const { locale } = useLocale()
-    const { pantheonVersions } = useRaidHubManifest()
     const { data: rawRecentActivity } = useRaidHubActivtiesFirstPage(destinyMembershipId, {
         select: res =>
             res.activities.find(a => a.playerCount < 50) ?? res.activities.find(() => true),
         suspense: true
     })
 
-    const { data: latestActivity } = useRaidHubInstance(rawRecentActivity?.instanceId ?? "", {
-        enabled: !!rawRecentActivity,
+    if (!rawRecentActivity) {
+        return null
+    }
+
+    return (
+        <LatestRaidCard
+            destinyMembershipId={destinyMembershipId}
+            instanceId={rawRecentActivity.instanceId}
+        />
+    )
+}
+
+const LatestRaidCard = ({
+    destinyMembershipId,
+    instanceId
+}: {
+    destinyMembershipId: string
+    instanceId: string
+}) => {
+    const { locale } = useLocale()
+    const { pantheonVersions } = useRaidHubManifest()
+    const { data: latestActivity } = useRaidHubInstance(instanceId, {
         suspense: true
     })
 


### PR DESCRIPTION
## Summary
- Fix profile pages getting stuck on the transitory loading skeleton above the tab bar when a player is not currently in game
- Only mount suspense-backed Bungie live-data and instance fetches when those queries are actually enabled
- Split Current Activity and Latest Raid into separate Suspense boundaries so one card cannot block the other

## Test plan
- [x] Opened `https://localhost:3000/profile/4611686018474925281?tab=pantheon` locally
- [x] Verified transitory skeleton clears and Latest Raid card renders for offline profiles
- [x] `bun run lint`


Made with [Cursor](https://cursor.com)