### PR TITLE
Fix Sentry init in production

### DIFF
--- a/example.env
+++ b/example.env
@@ -30,7 +30,9 @@ AWS_S3_BUCKET_NAME="your-bucket-name-here"
 AWS_S3_REGION="us-east-1"
 
 ### Sentry (optional) — same as RaidHub-API. Inlined for client via `next.config.js` `env` (not NEXT_PUBLIC_*).
+# Prefer SENTRY_DSN; NEXT_PUBLIC_SENTRY_DSN is supported as a fallback (Vercel Sentry integration).
 # SENTRY_DSN=""
+# NEXT_PUBLIC_SENTRY_DSN=""
 # SENTRY_ENVIRONMENT="development"
 # SENTRY_RELEASE=""
 

--- a/next.config.js
+++ b/next.config.js
@@ -23,6 +23,7 @@ const nextConfig = {
         RAIDHUB_API_URL: process.env.RAIDHUB_API_URL ?? "https://api.raidhub.io",
         RAIDHUB_API_KEY: process.env.RAIDHUB_API_KEY,
         SENTRY_DSN: process.env.SENTRY_DSN,
+        NEXT_PUBLIC_SENTRY_DSN: process.env.NEXT_PUBLIC_SENTRY_DSN,
         SENTRY_ENVIRONMENT: process.env.SENTRY_ENVIRONMENT,
         SENTRY_RELEASE: process.env.SENTRY_RELEASE
     },

--- a/src/lib/sentry/env.ts
+++ b/src/lib/sentry/env.ts
@@ -3,7 +3,7 @@
  * For the browser, `next.config.js` `env` inlines these at build time (same pattern as `APP_VERSION`), not `NEXT_PUBLIC_*`.
  */
 export function getSentryDsnForServer(): string | undefined {
-    const dsn = process.env.SENTRY_DSN?.trim()
+    const dsn = process.env.SENTRY_DSN?.trim() ?? process.env.NEXT_PUBLIC_SENTRY_DSN?.trim()
     return dsn && dsn.length > 0 ? dsn : undefined
 }
 


### PR DESCRIPTION
## Summary
- Fall back to `NEXT_PUBLIC_SENTRY_DSN` when `SENTRY_DSN` is unset
- Inline `NEXT_PUBLIC_SENTRY_DSN` via `next.config.js` `env` for client bundles
- Added matching `SENTRY_DSN` in Vercel Production env (was only `NEXT_PUBLIC_SENTRY_DSN` before)

Prod client JS had Sentry SDK + gated `Sentry.init`, but no DSN was inlined because the app read `SENTRY_DSN` while Vercel only provided `NEXT_PUBLIC_SENTRY_DSN`.

## Test plan
- [x] `bun run lint` passes locally
- [ ] After deploy, prod `main-app` chunk should include an ingest DSN and run `Sentry.init`
- [ ] Sentry dashboard should receive events from raidhub.io


Made with [Cursor](https://cursor.com)