### PR TITLE
Fix production APP_VERSION bump using git tags

### DIFF
--- a/.github/scripts/bump-app-version.sh
+++ b/.github/scripts/bump-app-version.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Encrypted Vercel env vars are not readable from `vercel pull`, so git tags are
+# the source of truth for the production patch number (vYYYY.M.D.P).
+CURRENT_YEAR=$(date +%Y)
+CURRENT_MONTH=$(date +%-m)
+CURRENT_DAY=$(date +%-d)
+DATE_PREFIX="${CURRENT_YEAR}.${CURRENT_MONTH}.${CURRENT_DAY}"
+TAG_PREFIX="v${DATE_PREFIX}."
+
+LATEST_TAG=$(git tag -l "${TAG_PREFIX}*" | sort -V | tail -1 || true)
+
+if [[ -n "$LATEST_TAG" ]]; then
+    PATCH="${LATEST_TAG#"${TAG_PREFIX}"}"
+    PATCH=$((PATCH + 1))
+else
+    PATCH=0
+fi
+
+APP_VERSION="${DATE_PREFIX}.${PATCH}"
+echo "Computed APP_VERSION=${APP_VERSION} (latest tag: ${LATEST_TAG:-none})"
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+    echo "APP_VERSION=${APP_VERSION}" >>"$GITHUB_ENV"
+fi

--- a/.github/scripts/create-release-tag.sh
+++ b/.github/scripts/create-release-tag.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TAG_NAME="v${APP_VERSION}"
+COMMIT_SHA="${1:?commit sha required}"
+GITHUB_TOKEN="${2:?github token required}"
+REPOSITORY="${3:?repository owner/name required}"
+
+OWNER="${REPOSITORY%%/*}"
+REPO="${REPOSITORY#*/}"
+
+response="$(
+    curl -sS -w "\n%{http_code}" -X POST \
+        -H "Authorization: token ${GITHUB_TOKEN}" \
+        -H "Accept: application/vnd.github+json" \
+        "https://api.github.com/repos/${OWNER}/${REPO}/git/refs" \
+        -d "{\"ref\":\"refs/tags/${TAG_NAME}\",\"sha\":\"${COMMIT_SHA}\"}"
+)"
+
+http_code="${response##*$'\n'}"
+body="${response%$'\n'*}"
+
+if [[ "$http_code" == "201" ]]; then
+    echo "Created tag ${TAG_NAME}"
+    exit 0
+fi
+
+if [[ "$http_code" == "422" ]] && echo "$body" | grep -q "Reference already exists"; then
+    echo "Tag ${TAG_NAME} already exists"
+    exit 0
+fi
+
+echo "Failed to create tag ${TAG_NAME} (HTTP ${http_code}): ${body}" >&2
+exit 1

--- a/.github/workflows/deploy-prod.yaml
+++ b/.github/workflows/deploy-prod.yaml
@@ -22,6 +22,8 @@ jobs:
         steps:
             - name: Checkout
               uses: actions/checkout@v4
+              with:
+                  fetch-tags: true
 
             - name: Setup Bun
               uses: oven-sh/setup-bun@v1
@@ -45,31 +47,10 @@ jobs:
               run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
 
             - name: Set APP_VERSION
-              shell: bash
               run: |
-                  VERSION=$(grep -E '^APP_VERSION=' .vercel/.env.production.local | cut -d '=' -f 2 | sed 's/"//g; s/\\n//')
-
-                  VERSION_ARRAY=($(echo -n "$VERSION" | awk -F'.' '{print $1,$2,$3,$4}'))
-
-                  # Get the first three numbers in the version
-                  YEAR=${VERSION_ARRAY[0]}
-                  MONTH=${VERSION_ARRAY[1]}
-                  DAY=${VERSION_ARRAY[2]}
-                  PATCH=${VERSION_ARRAY[3]}
-
-                  # Get the current year, month, and day
-                  CURRENT_YEAR=$(date +%Y)
-                  CURRENT_MONTH=$(date +%-m)
-                  CURRENT_DAY=$(date +%-d)
-
-                  # Check if the major, minor, and patch version numbers match the current date
-                  if [[ "$YEAR" == "$CURRENT_YEAR" && "$MONTH" == "$CURRENT_MONTH" && "$DAY" == "$CURRENT_DAY" ]]; then
-                    PATCH=$((PATCH+1))
-                  else
-                    PATCH=0
-                  fi
-
-                  echo "APP_VERSION=${CURRENT_YEAR}.${CURRENT_MONTH}.${CURRENT_DAY}.${PATCH}" >> $GITHUB_ENV
+                  git fetch --tags --force origin
+                  chmod +x ./.github/scripts/bump-app-version.sh
+                  ./.github/scripts/bump-app-version.sh
 
             - name: Apply Database Migrations
               env:
@@ -114,13 +95,8 @@ jobs:
 
             - name: Create Tag
               run: |
-                  TAG_NAME="v$APP_VERSION"
-                  COMMIT_SHA="${{ github.sha }}"
-                  OWNER=$(echo "${{ github.repository }}" | cut -d '/' -f 1)
-                  REPO=$(echo "${{ github.repository }}" | cut -d '/' -f 2)
-
-                  curl -X POST \
-                    -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-                    -H "Accept: application/vnd.github.v3+json" \
-                    "https://api.github.com/repos/$OWNER/$REPO/git/refs" \
-                    -d "{\"ref\":\"refs/tags/$TAG_NAME\",\"sha\":\"$COMMIT_SHA\",\"tagger\":{\"name\":\"${{ github.actor }}\",\"email\":\"${{ github.actor }}@users.noreply.github.com\",\"date\":\"$(date --iso-8601=seconds)\"}}"
+                  chmod +x ./.github/scripts/create-release-tag.sh
+                  ./.github/scripts/create-release-tag.sh \
+                    "${{ github.sha }}" \
+                    "${{ secrets.GITHUB_TOKEN }}" \
+                    "${{ github.repository }}"


### PR DESCRIPTION
## Summary
- Bump `APP_VERSION` from the latest `vYYYY.M.D.P` git tag instead of grepping `vercel pull` output.
- `APP_VERSION` is encrypted in Vercel, so `vercel pull` always returned an empty string and every deploy reset the patch to `.0`.
- Harden tag creation with explicit HTTP status handling instead of silently ignoring failures.

## Test plan
- [ ] Merge to `main` and confirm **Deploy to Production** logs `Computed APP_VERSION=...` with an incremented patch.
- [ ] Verify footer on https://raidhub.io shows the new patch (not stuck at `.0`).
- [ ] Confirm a new `vYYYY.M.D.P` tag is created on the merge commit.

Made with [Cursor](https://cursor.com)