### PR TITLE
Fix production Sentry noise and coverage gaps

### DIFF
--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -5,6 +5,7 @@ import {
     getSentryRelease,
     getTracesSampleRate
 } from "./src/lib/sentry/env"
+import { sentrySharedOptions } from "./src/lib/sentry/shared-options"
 
 const dsn = getSentryDsnForServer()
 
@@ -14,6 +15,7 @@ if (dsn) {
         environment: getSentryEnvironment(),
         release: getSentryRelease(),
         tracesSampleRate: getTracesSampleRate(),
-        debug: process.env.NODE_ENV !== "production"
+        debug: process.env.NODE_ENV !== "production",
+        ...sentrySharedOptions
     })
 }

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -5,6 +5,7 @@ import {
     getSentryRelease,
     getTracesSampleRate
 } from "./src/lib/sentry/env"
+import { sentrySharedOptions } from "./src/lib/sentry/shared-options"
 
 const dsn = getSentryDsnForServer()
 
@@ -14,6 +15,7 @@ if (dsn) {
         environment: getSentryEnvironment(),
         release: getSentryRelease(),
         tracesSampleRate: getTracesSampleRate(),
-        debug: process.env.NODE_ENV !== "production"
+        debug: process.env.NODE_ENV !== "production",
+        ...sentrySharedOptions
     })
 }

--- a/src/app/(profile)/user/[vanity]/page.tsx
+++ b/src/app/(profile)/user/[vanity]/page.tsx
@@ -72,7 +72,10 @@ const HydratedVanityPage = async (appProfile: NonNullable<AppProfile>) => {
 }
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-    const profile = await getUniqueProfileByVanity(params.vanity).then(p => p ?? notFound())
+    const profile = await getUniqueProfileByVanity(params.vanity)
+    if (!profile) {
+        return {}
+    }
 
     const raidhub = await prefetchRaidHubPlayerProfile(profile.destinyMembershipId)
 

--- a/src/app/leaderboards/individual/[raid]/[category]/page.tsx
+++ b/src/app/leaderboards/individual/[raid]/[category]/page.tsx
@@ -6,7 +6,7 @@ import { prefetchManifest } from "~/services/raidhub/prefetchRaidHubManifest"
 import { type PathParamsForLeaderboardURL } from "~/services/raidhub/types"
 import { Leaderboard } from "../../../Leaderboard"
 import { Splash } from "../../../LeaderboardSplashComponents"
-import { getRaidDefinition } from "../../../util"
+import { getRaidDefinition, tryGetRaidDefinition } from "../../../util"
 
 export const dynamicParams = true
 export const revalidate = 900
@@ -33,7 +33,10 @@ const getCategoryName = (category: DynamicParams["params"]["category"]) => {
 
 export async function generateMetadata({ params }: DynamicParams): Promise<Metadata> {
     const manifest = await prefetchManifest()
-    const definition = getRaidDefinition(params.raid, manifest)
+    const definition = tryGetRaidDefinition(params.raid, manifest)
+    if (!definition) {
+        return {}
+    }
     const categoryName = getCategoryName(params.category)
 
     const title = `${definition.name} ${categoryName} Leaderboard`

--- a/src/app/leaderboards/individual/global/[category]/page.tsx
+++ b/src/app/leaderboards/individual/global/[category]/page.tsx
@@ -15,23 +15,24 @@ export const fetchCache = "default-no-store"
 type CategoryParam =
     PathParamsForLeaderboardURL<"/leaderboard/individual/global/{category}">["category"]
 
+const GLOBAL_CATEGORY_TITLES = {
+    clears: "Clears",
+    "full-clears": "Full Clears",
+    sherpas: "Sherpas",
+    speedrun: "Speedrun",
+    "world-first-rankings": "World First Rating",
+    "in-raid-time": "In Raid Time"
+} as const satisfies Record<CategoryParam, string>
+
+const tryGetCategoryTitle = (category: string) =>
+    GLOBAL_CATEGORY_TITLES[category as CategoryParam] ?? null
+
 const getCategoryTitle = (category: CategoryParam) => {
-    switch (category) {
-        case "clears":
-            return "Clears"
-        case "full-clears":
-            return "Full Clears"
-        case "sherpas":
-            return "Sherpas"
-        case "speedrun":
-            return "Speedrun"
-        case "world-first-rankings":
-            return "World First Rating"
-        case "in-raid-time":
-            return "In Raid Time"
-        default:
-            notFound()
+    const title = tryGetCategoryTitle(category)
+    if (!title) {
+        notFound()
     }
+    return title
 }
 
 type DynamicParams = {
@@ -42,7 +43,10 @@ type DynamicParams = {
 }
 
 export async function generateMetadata({ params }: DynamicParams): Promise<Metadata> {
-    const categoryName = getCategoryTitle(params.category)
+    const categoryName = tryGetCategoryTitle(params.category)
+    if (!categoryName) {
+        return {}
+    }
     const title = `${categoryName} Leaderboards`
     const description = `View the Destiny 2 raid ${categoryName.toLowerCase()} leaderboard`
 

--- a/src/app/leaderboards/individual/pantheon/[version]/[category]/page.tsx
+++ b/src/app/leaderboards/individual/pantheon/[version]/[category]/page.tsx
@@ -22,14 +22,14 @@ type PantheonVersionLeaderboardDynamicParams = {
     searchParams: Record<string, string>
 }
 
-const getDefinitions = (
+const tryGetDefinitions = (
     params: PantheonVersionLeaderboardDynamicParams["params"],
     manifest: RaidHubManifestResponse
 ) => {
     const definition = findPantheonVersionByPath(manifest, params.version)
 
     if (!definition?.associatedActivityId) {
-        return notFound()
+        return null
     }
 
     const activity = manifest.activityDefinitions[definition.associatedActivityId] ?? null
@@ -41,11 +41,28 @@ const getDefinitions = (
     }
 }
 
+const getDefinitions = (
+    params: PantheonVersionLeaderboardDynamicParams["params"],
+    manifest: RaidHubManifestResponse
+) => {
+    const definitions = tryGetDefinitions(params, manifest)
+    if (!definitions) {
+        return notFound()
+    }
+
+    return definitions
+}
+
 export async function generateMetadata({
     params
 }: PantheonVersionLeaderboardDynamicParams): Promise<Metadata> {
     const manifest = await prefetchManifest()
-    const { definition, activity, categoryName } = getDefinitions(params, manifest)
+    const definitions = tryGetDefinitions(params, manifest)
+    if (!definitions) {
+        return {}
+    }
+
+    const { definition, activity, categoryName } = definitions
     const activityName = activity?.name ?? "The Pantheon"
 
     const title = `${activityName}: ${definition.name} ${categoryName} Completion Leaderboard`

--- a/src/app/leaderboards/team/[raid]/first/[version]/page.tsx
+++ b/src/app/leaderboards/team/[raid]/first/[version]/page.tsx
@@ -22,28 +22,56 @@ type DynamicParams = {
     searchParams: Record<string, string>
 }
 
-const getDefinitions = (params: DynamicParams["params"], manifest: RaidHubManifestResponse) => {
+const tryGetDefinitions = (params: DynamicParams["params"], manifest: RaidHubManifestResponse) => {
     if (params.raid === "pantheon") {
-        const version = findPantheonVersionByPath(manifest, params.version) ?? notFound()
-        const activity = manifest.activityDefinitions[version.associatedActivityId!] ?? notFound()
+        const version = findPantheonVersionByPath(manifest, params.version)
+        if (!version?.associatedActivityId) {
+            return null
+        }
+
+        const activity = manifest.activityDefinitions[version.associatedActivityId] ?? null
+        if (!activity) {
+            return null
+        }
 
         return { version, activity, isPantheon: true as const }
     }
 
+    const version = Object.values(manifest.versionDefinitions).find(
+        def => def.path === params.version
+    )
+    const activity = Object.values(manifest.activityDefinitions).find(
+        def => def.path === params.raid
+    )
+
+    if (!version || !activity) {
+        return null
+    }
+
     return {
-        version:
-            Object.values(manifest.versionDefinitions).find(def => def.path === params.version) ??
-            notFound(),
-        activity:
-            Object.values(manifest.activityDefinitions).find(def => def.path === params.raid) ??
-            notFound(),
+        version,
+        activity,
         isPantheon: false as const
     }
 }
 
+const getDefinitions = (params: DynamicParams["params"], manifest: RaidHubManifestResponse) => {
+    const definitions = tryGetDefinitions(params, manifest)
+    if (!definitions) {
+        return notFound()
+    }
+
+    return definitions
+}
+
 export async function generateMetadata({ params }: DynamicParams): Promise<Metadata> {
     const manifest = await prefetchManifest()
-    const { version, activity, isPantheon } = getDefinitions(params, manifest)
+    const definitions = tryGetDefinitions(params, manifest)
+    if (!definitions) {
+        return {}
+    }
+
+    const { version, activity, isPantheon } = definitions
 
     const title = isPantheon
         ? `${activity.name}: ${version.name} First Completions Leaderboard`

--- a/src/app/leaderboards/team/[raid]/speedrun/[category]/page.tsx
+++ b/src/app/leaderboards/team/[raid]/speedrun/[category]/page.tsx
@@ -4,7 +4,7 @@ import { Leaderboard } from "~/app/leaderboards/Leaderboard"
 import { baseMetadata } from "~/lib/metadata"
 import { SpeedrunVariables, type RTABoardCategory } from "~/lib/speedrun/speedrun-com-mappings"
 import { prefetchManifest } from "~/services/raidhub/prefetchRaidHubManifest"
-import { getRaidDefinition } from "../../../../util"
+import { getRaidDefinition, tryGetRaidDefinition } from "../../../../util"
 import { SpeedrunComBanner } from "./SpeedrunComBanner"
 import { SpeedrunComControls } from "./SpeedrunComControls"
 import { SpeedrunEntries } from "./SpeedrunEntries"
@@ -47,10 +47,15 @@ export async function generateStaticParams() {
 
 export async function generateMetadata({ params }: DynamicParams): Promise<Metadata> {
     const manifest = await prefetchManifest()
-    const definition = getRaidDefinition(params.raid, manifest)
-    const categoryId = SpeedrunVariables[definition.path]?.categoryId
+    const definition = tryGetRaidDefinition(params.raid, manifest)
+    if (!definition) {
+        return {}
+    }
 
-    if (!categoryId) return notFound()
+    const categoryId = SpeedrunVariables[definition.path]?.categoryId
+    if (!categoryId) {
+        return {}
+    }
 
     const displayName =
         params.category !== "all"

--- a/src/app/leaderboards/team/[raid]/worldfirst/page.tsx
+++ b/src/app/leaderboards/team/[raid]/worldfirst/page.tsx
@@ -6,7 +6,7 @@ import { prefetchManifest } from "~/services/raidhub/prefetchRaidHubManifest"
 import { type PathParamsForLeaderboardURL } from "~/services/raidhub/types"
 import { Leaderboard } from "../../../Leaderboard"
 import { Splash } from "../../../LeaderboardSplashComponents"
-import { getRaidDefinition } from "../../../util"
+import { getRaidDefinition, tryGetRaidDefinition } from "../../../util"
 
 export const dynamicParams = true
 export const revalidate = 900
@@ -20,7 +20,10 @@ type DynamicParams = {
 
 export async function generateMetadata({ params }: DynamicParams): Promise<Metadata> {
     const manifest = await prefetchManifest()
-    const definition = getRaidDefinition(params.raid, manifest)
+    const definition = tryGetRaidDefinition(params.raid, manifest)
+    if (!definition) {
+        return {}
+    }
 
     const title = `${definition.name} World First Leaderboard`
     const description = `View the World First completions for ${definition.name}`

--- a/src/app/leaderboards/team/custom/pantheon-community-race/page.tsx
+++ b/src/app/leaderboards/team/custom/pantheon-community-race/page.tsx
@@ -5,6 +5,11 @@ import { CloudflareActivitySplash } from "~/components/CloudflareImage"
 import { getActivePantheonIds, PANTHEON_COMMUNITY_RACE_VERSION_ID } from "~/lib/manifest/pantheon"
 import { baseMetadata } from "~/lib/metadata"
 import { prefetchManifest } from "~/services/raidhub/prefetchRaidHubManifest"
+import {
+    type RaidHubActivityDefinition,
+    type RaidHubManifestResponse,
+    type RaidHubVersionDefinition
+} from "~/services/raidhub/types"
 import { Leaderboard } from "../../../Leaderboard"
 import { Splash } from "../../../LeaderboardSplashComponents"
 
@@ -12,15 +17,28 @@ export const revalidate = 900
 export const dynamic = "force-static"
 export const fetchCache = "default-no-store"
 
-export async function generateMetadata(): Promise<Metadata> {
-    const manifest = await prefetchManifest()
+const tryGetCommunityRaceDefinitions = (
+    manifest: RaidHubManifestResponse
+): { activity: RaidHubActivityDefinition; version: RaidHubVersionDefinition } | null => {
     const activityId = getActivePantheonIds(manifest)[0]
     const activity = activityId != null ? manifest.activityDefinitions[activityId] : undefined
     const version = manifest.versionDefinitions[PANTHEON_COMMUNITY_RACE_VERSION_ID]
 
     if (!activity || version?.associatedActivityId == null) {
-        notFound()
+        return null
     }
+
+    return { activity, version }
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+    const manifest = await prefetchManifest()
+    const definitions = tryGetCommunityRaceDefinitions(manifest)
+    if (!definitions) {
+        return {}
+    }
+
+    const { activity, version } = definitions
 
     const title = `${activity.name}: ${version.name} Community Race Leaderboard`
     const description = `View community race placements for ${version.name} in ${activity.name}`
@@ -45,13 +63,13 @@ export async function generateMetadata(): Promise<Metadata> {
 
 export default async function Page({ searchParams }: { searchParams: Record<string, string> }) {
     const manifest = await prefetchManifest()
-    const activityId = getActivePantheonIds(manifest)[0]
-    const activity = activityId != null ? manifest.activityDefinitions[activityId] : undefined
-    const version = manifest.versionDefinitions[PANTHEON_COMMUNITY_RACE_VERSION_ID]
+    const definitions = tryGetCommunityRaceDefinitions(manifest)
 
-    if (!activity || version?.associatedActivityId == null) {
+    if (!definitions) {
         notFound()
     }
+
+    const { activity, version } = definitions
 
     return (
         <Leaderboard
@@ -61,7 +79,7 @@ export default async function Page({ searchParams }: { searchParams: Record<stri
                     title={version.name}
                     subtitle="Community Race Leaderboard">
                     <CloudflareActivitySplash
-                        activityId={version.associatedActivityId}
+                        activityId={version.associatedActivityId!}
                         versionId={version.id}
                         fill
                         className="z-[-1]"

--- a/src/app/leaderboards/util.ts
+++ b/src/app/leaderboards/util.ts
@@ -1,9 +1,13 @@
 import { notFound } from "next/navigation"
 import { type RaidHubManifestResponse } from "~/services/raidhub/types"
 
-export const getRaidDefinition = (raid: string, manifest: RaidHubManifestResponse) => {
+export const tryGetRaidDefinition = (raid: string, manifest: RaidHubManifestResponse) => {
     return (
         Object.values(manifest.activityDefinitions).find(def => def.isRaid && def.path === raid) ??
-        notFound()
+        null
     )
+}
+
+export const getRaidDefinition = (raid: string, manifest: RaidHubManifestResponse) => {
+    return tryGetRaidDefinition(raid, manifest) ?? notFound()
 }

--- a/src/app/pgcr/[instanceId]/page.tsx
+++ b/src/app/pgcr/[instanceId]/page.tsx
@@ -3,7 +3,12 @@ import type { Metadata } from "next"
 import { PageWrapper } from "~/components/PageWrapper"
 import PGCR from "~/components/pgcr/pgcr-view"
 import { baseMetadata } from "~/lib/metadata"
-import { assertValidPath, getMetaData, prefetchActivity } from "~/lib/pgcr/server"
+import {
+    assertValidPath,
+    getMetaData,
+    prefetchActivity,
+    tryPrefetchActivity
+} from "~/lib/pgcr/server"
 import { type PGCRPageProps } from "~/lib/pgcr/types"
 
 export const revalidate = 0
@@ -19,8 +24,11 @@ export default async function Page({ params }: PGCRPageProps) {
 }
 
 export async function generateMetadata({ params }: PGCRPageProps): Promise<Metadata> {
-    assertValidPath(params.instanceId)
-    const activity = await prefetchActivity(params.instanceId)
+    if (!/^\d+$/.test(params.instanceId)) {
+        return {}
+    }
+
+    const activity = await tryPrefetchActivity(params.instanceId)
 
     if (!activity) {
         return {

--- a/src/components/providers/QueryManager.tsx
+++ b/src/components/providers/QueryManager.tsx
@@ -1,10 +1,13 @@
 "use client"
 
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { QueryCache, QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
-import { httpLink, loggerLink } from "@trpc/client"
+import { httpLink, loggerLink, type TRPCLink } from "@trpc/client"
+import { observable } from "@trpc/server/observable"
 import { useState } from "react"
 import superjson from "superjson"
+import { captureClientException } from "~/lib/sentry/capture"
+import { type AppRouter } from "~/lib/server/trpc"
 import { trpc } from "~/lib/trpc"
 
 function getBaseUrl() {
@@ -13,10 +16,43 @@ function getBaseUrl() {
     return `https://localhost:${process.env.PORT ?? 3000}`
 }
 
+const sentryLink: TRPCLink<AppRouter> = () => {
+    return ({ next, op }) => {
+        return observable(observer => {
+            const subscription = next(op).subscribe({
+                next(value) {
+                    observer.next(value)
+                },
+                error(error) {
+                    captureClientException(error, {
+                        source: "trpc-client",
+                        trpc_path: op.path,
+                        trpc_type: op.type
+                    })
+                    observer.error(error)
+                },
+                complete() {
+                    observer.complete()
+                }
+            })
+
+            return () => subscription.unsubscribe()
+        })
+    }
+}
+
 export function QueryManager(props: { children: React.ReactNode }) {
     const [queryClient] = useState(
         () =>
             new QueryClient({
+                queryCache: new QueryCache({
+                    onError: (error, query) => {
+                        captureClientException(error, {
+                            source: "react-query",
+                            queryKey: JSON.stringify(query.queryKey)
+                        })
+                    }
+                }),
                 defaultOptions: {
                     queries: {
                         staleTime: 60000,
@@ -27,6 +63,11 @@ export function QueryManager(props: { children: React.ReactNode }) {
                         suspense: false,
                         useErrorBoundary: false,
                         retryDelay: failureCount => Math.min(2 ** failureCount * 1000, 30_000)
+                    },
+                    mutations: {
+                        onError: error => {
+                            captureClientException(error, { source: "react-query-mutation" })
+                        }
                     }
                 }
             })
@@ -41,6 +82,7 @@ export function QueryManager(props: { children: React.ReactNode }) {
                         process.env.NODE_ENV === "development" ||
                         (op.direction === "down" && op.result instanceof Error)
                 }),
+                sentryLink,
                 httpLink({
                     url: getBaseUrl() + "/api/trpc"
                 })

--- a/src/components/providers/QueryManager.tsx
+++ b/src/components/providers/QueryManager.tsx
@@ -47,6 +47,11 @@ export function QueryManager(props: { children: React.ReactNode }) {
             new QueryClient({
                 queryCache: new QueryCache({
                     onError: (error, query) => {
+                        // tRPC errors are captured by sentryLink — avoid double-reporting.
+                        if (Array.isArray(query.queryKey[0])) {
+                            return
+                        }
+
                         captureClientException(error, {
                             source: "react-query",
                             queryKey: JSON.stringify(query.queryKey)

--- a/src/components/providers/RaidHubManifestManager.tsx
+++ b/src/components/providers/RaidHubManifestManager.tsx
@@ -52,7 +52,8 @@ export function RaidHubManifestManager(props: {
 }) {
     const { data } = useQuery<RaidHubManifestResponse>({
         queryKey: ["raidhub-manifest"],
-        queryFn: () => getRaidHubApi("/manifest", null, null).then(res => res.response),
+        queryFn: ({ signal }) =>
+            getRaidHubApi("/manifest", null, null, { signal }).then(res => res.response),
         initialData: props.serverManifest,
         staleTime: 1000 * 3600 // 1 hour
     })

--- a/src/components/providers/SentryUserSync.tsx
+++ b/src/components/providers/SentryUserSync.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import * as Sentry from "@sentry/nextjs"
+import { useEffect } from "react"
+import { useSession } from "~/hooks/app/useSession"
+
+export function SentryUserSync() {
+    const session = useSession()
+
+    useEffect(() => {
+        if (session.status === "authenticated") {
+            Sentry.setUser({ id: session.data.user.id })
+            if (session.data.primaryDestinyMembershipId) {
+                Sentry.setTag("primary_membership_id", session.data.primaryDestinyMembershipId)
+            }
+            return
+        }
+
+        Sentry.setUser(null)
+        Sentry.setTag("primary_membership_id", undefined)
+    }, [session])
+
+    return null
+}

--- a/src/components/providers/session/ClientSessionManager.tsx
+++ b/src/components/providers/session/ClientSessionManager.tsx
@@ -3,6 +3,7 @@
 import { type Session } from "next-auth"
 import { SessionProvider, signOut } from "next-auth/react"
 import { useEffect, useRef, useState, type ReactNode } from "react"
+import { SentryUserSync } from "~/components/providers/SentryUserSync"
 import { useSession } from "~/hooks/app/useSession"
 import { useBungieClient } from "./BungieClientProvider"
 
@@ -27,6 +28,7 @@ export const ClientSessionManager = (props: {
             refetchOnWindowFocus={false}
             refetchWhenOffline={false}
             session={props.serverSession}>
+            <SentryUserSync />
             <TokenManager setNextRefetch={setSessionRefetchInterval} />
             {props.children}
         </SessionProvider>

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -5,6 +5,7 @@ import {
     getSentryRelease,
     getTracesSampleRate
 } from "./lib/sentry/env"
+import { sentrySharedOptions } from "./lib/sentry/shared-options"
 
 const dsn = getSentryDsnForClient()
 
@@ -14,7 +15,8 @@ if (dsn) {
         environment: getSentryEnvironment(),
         release: getSentryRelease(),
         tracesSampleRate: getTracesSampleRate(),
-        debug: process.env.NODE_ENV !== "production"
+        debug: process.env.NODE_ENV !== "production",
+        ...sentrySharedOptions
     })
 }
 

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,3 +1,5 @@
+import * as Sentry from "@sentry/nextjs"
+
 export async function register() {
     if (process.env.NEXT_RUNTIME === "nodejs") {
         await import("../sentry.server.config")
@@ -5,3 +7,5 @@ export async function register() {
         await import("../sentry.edge.config")
     }
 }
+
+export const onRequestError = Sentry.captureRequestError

--- a/src/lib/pgcr/server.ts
+++ b/src/lib/pgcr/server.ts
@@ -12,17 +12,26 @@ export const assertValidPath = (instanceId: string) => {
     }
 }
 
-export const prefetchActivity = reactRequestDedupe((instanceId: string) =>
+export const tryPrefetchActivity = reactRequestDedupe((instanceId: string) =>
     getRaidHubApi("/instance/{instanceId}", { instanceId }, null)
         .then(res => res.response)
         .catch(err => {
             if (err instanceof RaidHubError && err.errorCode === "InstanceNotFoundError") {
-                notFound()
+                return null
             } else {
                 throw err
             }
         })
 )
+
+export const prefetchActivity = reactRequestDedupe(async (instanceId: string) => {
+    const activity = await tryPrefetchActivity(instanceId)
+    if (!activity) {
+        notFound()
+    }
+
+    return activity
+})
 
 export const getMetaData = (activity: RaidHubInstanceExtended) => {
     const lowmanPrefix = activity.completed

--- a/src/lib/sentry/capture.ts
+++ b/src/lib/sentry/capture.ts
@@ -1,0 +1,75 @@
+import * as Sentry from "@sentry/nextjs"
+import { RaidHubError } from "~/services/raidhub/RaidHubError"
+import type { RaidHubErrorCode } from "~/services/raidhub/types"
+import { getSentryDsnForServer } from "./env"
+
+/** Expected API outcomes — surfaced in UI, not bugs. */
+const EXPECTED_RAIDHUB_ERROR_CODES = new Set<RaidHubErrorCode>([
+    "PlayerNotFoundError",
+    "PlayerPrivateProfileError",
+    "PlayerProtectedResourceError",
+    "InstanceNotFoundError",
+    "PGCRNotFoundError",
+    "PlayerNotOnLeaderboardError",
+    "PlayerNotInInstance",
+    "RaidNotFoundError",
+    "PantheonVersionNotFoundError",
+    "InvalidActivityVersionComboError",
+    "ClanNotFoundError",
+    "InsufficientPermissionsError",
+    "PathValidationError",
+    "QueryValidationError",
+    "BodyValidationError",
+    "BungieServiceOffline"
+])
+
+const EXPECTED_TRPC_ERROR_CODES = new Set(["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN", "BAD_REQUEST"])
+
+function isAbortError(error: unknown): boolean {
+    if (error instanceof DOMException && error.name === "AbortError") {
+        return true
+    }
+
+    return error instanceof Error && error.name === "AbortError"
+}
+
+function shouldCaptureClientError(error: unknown): boolean {
+    if (isAbortError(error)) {
+        return false
+    }
+
+    if (error instanceof RaidHubError && EXPECTED_RAIDHUB_ERROR_CODES.has(error.errorCode)) {
+        return false
+    }
+
+    if (error && typeof error === "object" && "data" in error) {
+        const code = (error as { data?: { code?: string } }).data?.code
+        if (code && EXPECTED_TRPC_ERROR_CODES.has(code)) {
+            return false
+        }
+    }
+
+    return true
+}
+
+export function captureClientException(error: unknown, context?: Record<string, unknown>): void {
+    if (!shouldCaptureClientError(error)) {
+        return
+    }
+
+    Sentry.captureException(error, { extra: context })
+}
+
+export function captureServerException(
+    error: unknown,
+    context?: {
+        tags?: Record<string, string>
+        extra?: Record<string, unknown>
+    }
+): void {
+    if (!getSentryDsnForServer()) {
+        return
+    }
+
+    Sentry.captureException(error, context)
+}

--- a/src/lib/sentry/shared-options.ts
+++ b/src/lib/sentry/shared-options.ts
@@ -1,0 +1,23 @@
+import type { ErrorEvent, EventHint } from "@sentry/nextjs"
+
+/** Next.js control-flow errors thrown by the App Router — not application bugs. */
+const NEXTJS_CONTROL_FLOW_ERRORS = ["NEXT_NOT_FOUND", "NEXT_REDIRECT"] as const
+
+export function shouldDropSentryEvent(event: ErrorEvent, _hint?: EventHint): boolean {
+    const values = event.exception?.values
+    if (!values?.length) {
+        return false
+    }
+
+    return values.some(value => {
+        const message = value.value ?? ""
+        return NEXTJS_CONTROL_FLOW_ERRORS.some(error => message.includes(error))
+    })
+}
+
+export const sentrySharedOptions = {
+    beforeSend(event: ErrorEvent, hint: EventHint) {
+        return shouldDropSentryEvent(event, hint) ? null : event
+    },
+    ignoreErrors: [...NEXTJS_CONTROL_FLOW_ERRORS]
+}

--- a/src/lib/server/auth/sessionCallback.ts
+++ b/src/lib/server/auth/sessionCallback.ts
@@ -3,6 +3,7 @@ import "server-only"
 import { type Adapter, type AdapterUser } from "@auth/core/adapters"
 import { type AuthConfig } from "@auth/core/types"
 import { refreshAuthorization } from "bungie-net-core/auth"
+import { captureServerException } from "~/lib/sentry/capture"
 import { prisma } from "~/lib/server/prisma"
 import { BungieServiceError } from "~/models/BungieAPIError"
 import ServerBungieClient from "~/services/bungie/ServerBungieClient"
@@ -82,6 +83,9 @@ async function refreshBungieAuth(bungie: BungieAccount, userId: string) {
                 }
             } else {
                 console.error("Unexpected error while refreshing Bungie auth", err)
+                captureServerException(err, {
+                    tags: { area: "session", operation: "bungie_token_refresh" }
+                })
             }
             errors.push("BungieAccessTokenError")
             return null
@@ -101,6 +105,9 @@ async function refreshBungieAuth(bungie: BungieAccount, userId: string) {
             }).catch(e => {
                 errors.push("PrismaError")
                 console.error("Failed to update Bungie access token", e)
+                captureServerException(e, {
+                    tags: { area: "session", operation: "bungie_token_persist" }
+                })
                 return null
             })
         }
@@ -174,6 +181,9 @@ async function refreshRaidHubBearer({
         .catch(e => {
             errors.push("RaidHubAuthorizationError")
             console.error("Failed to refresh RaidHub auth token", e)
+            captureServerException(e, {
+                tags: { area: "session", operation: "raidhub_token_refresh" }
+            })
             return null
         })
 
@@ -196,6 +206,9 @@ async function refreshRaidHubBearer({
             .catch(e => {
                 errors.push("PrismaError")
                 console.error("Failed to update RaidHub admin token", e)
+                captureServerException(e, {
+                    tags: { area: "session", operation: "raidhub_token_persist" }
+                })
             })
     }
 

--- a/src/lib/server/trpc/error-handler.ts
+++ b/src/lib/server/trpc/error-handler.ts
@@ -1,5 +1,5 @@
-import * as Sentry from "@sentry/nextjs"
 import type { ProcedureType, TRPCError } from "@trpc/server"
+import { captureServerException } from "~/lib/sentry/capture"
 import { getSentryDsnForServer } from "~/lib/sentry/env"
 
 export const trpcErrorHandler = async ({
@@ -18,7 +18,7 @@ export const trpcErrorHandler = async ({
 
     if (getSentryDsnForServer() && error.code === "INTERNAL_SERVER_ERROR") {
         const err = error.cause instanceof Error ? error.cause : error
-        Sentry.captureException(err, {
+        captureServerException(err, {
             tags: {
                 trpc_path: path ?? "unknown",
                 trpc_source: source

--- a/src/services/raidhub/useRaidHubStatus.ts
+++ b/src/services/raidhub/useRaidHubStatus.ts
@@ -5,7 +5,8 @@ import { type RaidHubStatusResponse } from "./types"
 export const useRaidHubStatus = () =>
     useQuery<RaidHubStatusResponse, Error>({
         queryKey: ["raidhub", "status"],
-        queryFn: () => getRaidHubApi("/status", null, null).then(res => res.response),
+        queryFn: ({ signal }) =>
+            getRaidHubApi("/status", null, null, { signal }).then(res => res.response),
         staleTime: 10000,
         refetchOnReconnect: true,
         refetchOnMount: true,


### PR DESCRIPTION
## Summary
- Fix root cause of `/checkpoints` and invalid-route Sentry errors: stop calling `notFound()` inside `generateMetadata` (page components still 404 correctly)
- Filter only `NEXT_NOT_FOUND` / `NEXT_REDIRECT` in Sentry — App Router control-flow, not bugs
- Wire `onRequestError` for reliable App Router server error capture
- Add client coverage: React Query cache errors, tRPC link, abort-safe fetch signals on layout queries
- Add server coverage: session token refresh/persist failures
- Attach anonymized user id to Sentry events via `SentryUserSync`

Fixes WEBSITE-1, WEBSITE-2, WEBSITE-3, WEBSITE-4, WEBSITE-5, WEBSITE-7, WEBSITE-8, WEBSITE-A

## Test plan
- [x] `bun run lint`
- [x] `bunx tsc --noEmit`
- [ ] Merge and confirm prior noisy issues stop recurring in Sentry
- [ ] Spot-check `/checkpoints`, invalid vanity URL, and homepage navigation (no console/Sentry regressions)


Made with [Cursor](https://cursor.com)