### PR TITLE
Fix Sentry batch 2: checkpoints, vanity PPR, client noise

### DIFF
--- a/src/app/(profile)/layout.tsx
+++ b/src/app/(profile)/layout.tsx
@@ -1,0 +1,8 @@
+import { type ReactNode } from "react"
+
+/** PPR + profile streaming causes client-side DOM reconciliation errors on vanity/profile routes. */
+export const experimental_ppr = false
+
+export default function ProfileLayout({ children }: { children: ReactNode }) {
+    return children
+}

--- a/src/app/(profile)/user/[vanity]/page.tsx
+++ b/src/app/(profile)/user/[vanity]/page.tsx
@@ -1,6 +1,5 @@
 import { type Metadata } from "next"
 import { notFound } from "next/navigation"
-import { Suspense } from "react"
 import { ProfileClientWrapper } from "~/components/profile/ProfileClientWrapper"
 import { ProfilePage } from "~/components/profile/ProfilePage"
 import { generatePlayerMetadata } from "~/lib/profile/metadata"
@@ -11,7 +10,6 @@ import {
 } from "~/lib/profile/prefetch"
 import { type ProfileProps } from "~/lib/profile/types"
 import { getServerSession } from "~/lib/server/auth"
-import { type AppProfile } from "~/types/api"
 import { bungieProfileIconUrl } from "~/util/destiny"
 
 export const revalidate = 0
@@ -26,28 +24,11 @@ type PageProps = {
  * This page preferably should be accessed at /:vanity through rewrites in next.config.js
  */
 export default async function Page({ params }: PageProps) {
-    // Find the app profile by vanity, and if it doesn't exist next will render a 404
-    const appProfile = await getUniqueProfileByVanity(params.vanity).then(p => p ?? notFound())
+    const appProfile = await getUniqueProfileByVanity(params.vanity)
+    if (!appProfile) {
+        notFound()
+    }
 
-    return (
-        <Suspense
-            fallback={
-                <ProfileClientWrapper
-                    pageProps={{
-                        ssrAppProfile: appProfile,
-                        destinyMembershipId: appProfile.destinyMembershipId,
-                        destinyMembershipType: appProfile.destinyMembershipType,
-                        ready: false
-                    }}>
-                    <ProfilePage destinyMembershipId={appProfile.destinyMembershipId} />
-                </ProfileClientWrapper>
-            }>
-            <HydratedVanityPage {...appProfile} />
-        </Suspense>
-    )
-}
-
-const HydratedVanityPage = async (appProfile: NonNullable<AppProfile>) => {
     const session = await getServerSession()
 
     const raidHubProfile = await (session?.raidHubAccessToken
@@ -64,6 +45,7 @@ const HydratedVanityPage = async (appProfile: NonNullable<AppProfile>) => {
         ssrRaidHubProfile: raidHubProfile,
         ready: true
     }
+
     return (
         <ProfileClientWrapper pageProps={pageProps}>
             <ProfilePage destinyMembershipId={pageProps.destinyMembershipId} />

--- a/src/app/checkpoints/page.tsx
+++ b/src/app/checkpoints/page.tsx
@@ -1,0 +1,6 @@
+import { notFound } from "next/navigation"
+
+/** Reserved path — without this page, /checkpoints is rewritten to /user/checkpoints and 404s via vanity lookup. */
+export default function CheckpointsPage() {
+    notFound()
+}

--- a/src/components/providers/DestinyManifestManager.tsx
+++ b/src/components/providers/DestinyManifestManager.tsx
@@ -61,6 +61,18 @@ const DestinyManifestManager = ({ children }: { children: ReactNode }) => {
             dexieDB.updateDefinitions(seedCache, args),
         onSuccess: setManifestVersion,
         onError: async (err: Error | Error[]) => {
+            const errors = Array.isArray(err) ? err : [err]
+
+            if (
+                errors.some(
+                    e =>
+                        e.name === "InvalidStateError" &&
+                        e.message.includes("IDBTransaction")
+                )
+            ) {
+                return
+            }
+
             setManifestVersion(null)
             console.warn(
                 `Failed to store the Destiny 2 manifest definitions with error(s): ${

--- a/src/components/providers/DestinyManifestManager.tsx
+++ b/src/components/providers/DestinyManifestManager.tsx
@@ -65,9 +65,7 @@ const DestinyManifestManager = ({ children }: { children: ReactNode }) => {
 
             if (
                 errors.some(
-                    e =>
-                        e.name === "InvalidStateError" &&
-                        e.message.includes("IDBTransaction")
+                    e => e.name === "InvalidStateError" && e.message.includes("IDBTransaction")
                 )
             ) {
                 return

--- a/src/lib/sentry/capture.ts
+++ b/src/lib/sentry/capture.ts
@@ -33,8 +33,27 @@ function isAbortError(error: unknown): boolean {
     return error instanceof Error && error.name === "AbortError"
 }
 
+/** CDN/API blips and offline clients — not application bugs. */
+function isTransientNetworkError(error: unknown): boolean {
+    if (!(error instanceof TypeError)) {
+        return false
+    }
+
+    const { message } = error
+    return message === "Failed to fetch" || message.startsWith("Load failed")
+}
+
+/** Dexie transaction aborted when the user navigates away mid-write. */
+function isDexieTransactionAbort(error: unknown): boolean {
+    return (
+        error instanceof DOMException &&
+        error.name === "InvalidStateError" &&
+        error.message.includes("IDBTransaction")
+    )
+}
+
 function shouldCaptureClientError(error: unknown): boolean {
-    if (isAbortError(error)) {
+    if (isAbortError(error) || isTransientNetworkError(error) || isDexieTransactionAbort(error)) {
         return false
     }
 

--- a/src/lib/sentry/shared-options.ts
+++ b/src/lib/sentry/shared-options.ts
@@ -3,6 +3,9 @@ import type { ErrorEvent, EventHint } from "@sentry/nextjs"
 /** Next.js control-flow errors thrown by the App Router — not application bugs. */
 const NEXTJS_CONTROL_FLOW_ERRORS = ["NEXT_NOT_FOUND", "NEXT_REDIRECT"] as const
 
+/** Expected user-facing auth outcomes (OAuth cancel, invalid callback state). */
+const EXPECTED_AUTH_ERRORS = ["CallbackRouteError"] as const
+
 export function shouldDropSentryEvent(event: ErrorEvent, _hint?: EventHint): boolean {
     const values = event.exception?.values
     if (!values?.length) {
@@ -11,7 +14,10 @@ export function shouldDropSentryEvent(event: ErrorEvent, _hint?: EventHint): boo
 
     return values.some(value => {
         const message = value.value ?? ""
-        return NEXTJS_CONTROL_FLOW_ERRORS.some(error => message.includes(error))
+        return (
+            NEXTJS_CONTROL_FLOW_ERRORS.some(error => message.includes(error)) ||
+            EXPECTED_AUTH_ERRORS.some(error => message.includes(error))
+        )
     })
 }
 
@@ -19,5 +25,5 @@ export const sentrySharedOptions = {
     beforeSend(event: ErrorEvent, hint: EventHint) {
         return shouldDropSentryEvent(event, hint) ? null : event
     },
-    ignoreErrors: [...NEXTJS_CONTROL_FLOW_ERRORS]
+    ignoreErrors: [...NEXTJS_CONTROL_FLOW_ERRORS, ...EXPECTED_AUTH_ERRORS]
 }


### PR DESCRIPTION
## Summary

- Add `/checkpoints` page so the vanity rewrite no longer routes it through `/user/checkpoints` → `notFound()` under PPR (fixes WEBSITE-3/4/5/9 — ~90 events on `/checkpoints`).
- Disable PPR for `(profile)` routes and remove vanity `Suspense` streaming split (fixes WEBSITE-K/E/H/C parentNode/ref/removeChild races).
- Skip Sentry capture for transient network failures (`Load failed`, `Failed to fetch`), Dexie IDB abort-on-navigation, and Auth.js `CallbackRouteError`.

Companion to #353.

## Test plan

- [ ] `bun run lint && bunx tsc --noEmit`
- [ ] Visit `https://localhost:3000/checkpoints` — should show 404 without RSC client error
- [ ] Visit a vanity URL (e.g. `/lazarskiy`) — profile loads normally
- [ ] Visit `/profile/<id>` — profile loads normally
- [ ] After merge/deploy: monitor Sentry for `/checkpoints` and vanity/profile DOM errors

Fixes WEBSITE-3, WEBSITE-4, WEBSITE-5, WEBSITE-6, WEBSITE-9, WEBSITE-D, WEBSITE-E, WEBSITE-G, WEBSITE-H, WEBSITE-J, WEBSITE-K, WEBSITE-M, WEBSITE-N, WEBSITE-P, WEBSITE-Q, WEBSITE-R


Made with [Cursor](https://cursor.com)