### PR TITLE
Fix Sentry batch 4: tooltip providers and network beforeSend

### DIFF
--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -19,11 +19,7 @@ function TooltipProvider({
 }
 
 function Tooltip({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Root>) {
-    return (
-        <TooltipProvider>
-            <TooltipPrimitive.Root data-slot="tooltip" {...props} />
-        </TooltipProvider>
-    )
+    return <TooltipPrimitive.Root data-slot="tooltip" {...props} />
 }
 
 function TooltipTrigger({ ...props }: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {

--- a/src/lib/sentry/shared-options.ts
+++ b/src/lib/sentry/shared-options.ts
@@ -6,6 +6,13 @@ const NEXTJS_CONTROL_FLOW_ERRORS = ["NEXT_NOT_FOUND", "NEXT_REDIRECT"] as const
 /** Expected user-facing auth outcomes (OAuth cancel, invalid callback state). */
 const EXPECTED_AUTH_ERRORS = ["CallbackRouteError"] as const
 
+/** Transient network failures surfaced by global handlers, not app bugs. */
+const TRANSIENT_NETWORK_ERRORS = [
+    "Load failed",
+    "Failed to fetch",
+    "NetworkError when attempting to fetch resource"
+] as const
+
 export function shouldDropSentryEvent(event: ErrorEvent, _hint?: EventHint): boolean {
     const values = event.exception?.values
     if (!values?.length) {
@@ -16,7 +23,8 @@ export function shouldDropSentryEvent(event: ErrorEvent, _hint?: EventHint): boo
         const message = value.value ?? ""
         return (
             NEXTJS_CONTROL_FLOW_ERRORS.some(error => message.includes(error)) ||
-            EXPECTED_AUTH_ERRORS.some(error => message.includes(error))
+            EXPECTED_AUTH_ERRORS.some(error => message.includes(error)) ||
+            TRANSIENT_NETWORK_ERRORS.some(error => message.includes(error))
         )
     })
 }
@@ -25,5 +33,9 @@ export const sentrySharedOptions = {
     beforeSend(event: ErrorEvent, hint: EventHint) {
         return shouldDropSentryEvent(event, hint) ? null : event
     },
-    ignoreErrors: [...NEXTJS_CONTROL_FLOW_ERRORS, ...EXPECTED_AUTH_ERRORS]
+    ignoreErrors: [
+        ...NEXTJS_CONTROL_FLOW_ERRORS,
+        ...EXPECTED_AUTH_ERRORS,
+        ...TRANSIENT_NETWORK_ERRORS
+    ]
 }


### PR DESCRIPTION
## Summary
- Remove nested `TooltipProvider` from each `Tooltip` instance — root layout already provides one (fixes Popper anchor update loops on profile/PGCR).
- Filter transient network errors in `beforeSend` for events caught by global handlers (not just `captureClientException`).

## Test plan
- [x] `bun run lint && bun run build`
- [ ] Profile badges and PGCR feat tooltips still work
- [ ] Monitor Sentry for WEBSITE-T, WEBSITE-Y/X, Load failed noise

Fixes WEBSITE-Y, WEBSITE-X, WEBSITE-C, WEBSITE-T


Made with [Cursor](https://cursor.com)