### PR TITLE
Fix Sentry batch 5: guard profile vanity replaceState

### DIFF
--- a/src/components/profile/ProfileClientWrapper.tsx
+++ b/src/components/profile/ProfileClientWrapper.tsx
@@ -14,15 +14,20 @@ export function ProfileClientWrapper({
     const vanity = pageProps.ssrAppProfile?.vanity
 
     useEffect(() => {
-        if (vanity && pathname.startsWith("/profile")) {
-            window.history.replaceState(
-                {
-                    vanity
-                },
-                "",
-                `/${vanity}`
-            )
+        if (!vanity || !pathname.startsWith("/profile")) {
+            return
         }
+
+        const targetPath = `/${vanity}`
+        if (window.location.pathname === targetPath) {
+            return
+        }
+
+        window.history.replaceState(
+            { vanity },
+            "",
+            `${targetPath}${window.location.search}${window.location.hash}`
+        )
     }, [vanity, pathname])
 
     return (


### PR DESCRIPTION
## Summary
- Only run `history.replaceState` when navigating from `/profile/:id` to `/:vanity` if the browser URL is not already the vanity path.

## Test plan
- [x] `bun run lint && bun run build`
- [ ] Profile with vanity loads at `/profile/:id` and URL updates to `/:vanity` once
- [ ] Direct vanity URL `/rosie` unchanged

Fixes WEBSITE-11, WEBSITE-W, WEBSITE-C


Made with [Cursor](https://cursor.com)