### PR TITLE
Fix Sentry batch 6: disable PPR and harden error filters

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,8 +8,7 @@ const withBundleAnalyzer = require("@next/bundle-analyzer")({
 /** @type {import('next').NextConfig} */
 const nextConfig = {
     experimental: {
-        ppr: true,
-        // Quiets Sentry → OpenTelemetry → debug → supports-color optional peer resolution noise during webpack
+        // Disabled: experimental React + PPR causes client DOM reconciliation errors on profile/vanity/PGCR routes.
         serverComponentsExternalPackages: ["supports-color"]
     },
     reactStrictMode: false,

--- a/src/app/(profile)/layout.tsx
+++ b/src/app/(profile)/layout.tsx
@@ -1,8 +1,0 @@
-import { type ReactNode } from "react"
-
-/** PPR + profile streaming causes client-side DOM reconciliation errors on vanity/profile routes. */
-export const experimental_ppr = false
-
-export default function ProfileLayout({ children }: { children: ReactNode }) {
-    return children
-}

--- a/src/app/checkpoints/page.tsx
+++ b/src/app/checkpoints/page.tsx
@@ -1,6 +1,6 @@
-import NotFound from "~/app/not-found"
+import { notFound } from "next/navigation"
 
 /** Reserved path — without this page, /checkpoints is rewritten to /user/checkpoints and 404s via vanity lookup. */
 export default function CheckpointsPage() {
-    return <NotFound />
+    notFound()
 }

--- a/src/lib/sentry/capture.ts
+++ b/src/lib/sentry/capture.ts
@@ -44,6 +44,7 @@ function isTransientNetworkError(error: unknown): boolean {
         const { message } = error
         return (
             message === "Failed to fetch" ||
+            message === "fetch failed" ||
             message.startsWith("Load failed") ||
             message.startsWith("NetworkError when attempting to fetch resource")
         )
@@ -52,6 +53,17 @@ function isTransientNetworkError(error: unknown): boolean {
     if (error instanceof Error && error.name === "TRPCClientError") {
         const { message } = error
         return message === "Failed to fetch" || message === "Load failed"
+    }
+
+    if (error instanceof Error && error.message.startsWith("Operation failed after")) {
+        let cause: unknown = error.cause
+        while (cause) {
+            if (cause instanceof TypeError && cause.message === "fetch failed") {
+                return true
+            }
+
+            cause = cause instanceof Error ? cause.cause : undefined
+        }
     }
 
     return false
@@ -66,8 +78,18 @@ function isDexieTransactionAbort(error: unknown): boolean {
     )
 }
 
-function shouldCaptureClientError(error: unknown): boolean {
-    if (isAbortError(error) || isTransientNetworkError(error) || isDexieTransactionAbort(error)) {
+/** Dexie unavailable in private browsing / storage-blocked WebViews. */
+function isDexieEnvironmentError(error: unknown): boolean {
+    return error instanceof Error && error.name === "OpenFailedError"
+}
+
+function shouldCaptureError(error: unknown): boolean {
+    if (
+        isAbortError(error) ||
+        isTransientNetworkError(error) ||
+        isDexieTransactionAbort(error) ||
+        isDexieEnvironmentError(error)
+    ) {
         return false
     }
 
@@ -86,7 +108,7 @@ function shouldCaptureClientError(error: unknown): boolean {
 }
 
 export function captureClientException(error: unknown, context?: Record<string, unknown>): void {
-    if (!shouldCaptureClientError(error)) {
+    if (!shouldCaptureError(error)) {
         return
     }
 
@@ -100,7 +122,7 @@ export function captureServerException(
         extra?: Record<string, unknown>
     }
 ): void {
-    if (!getSentryDsnForServer()) {
+    if (!getSentryDsnForServer() || !shouldCaptureError(error)) {
         return
     }
 

--- a/src/lib/sentry/shared-options.ts
+++ b/src/lib/sentry/shared-options.ts
@@ -4,7 +4,11 @@ import type { ErrorEvent, EventHint } from "@sentry/nextjs"
 const NEXTJS_CONTROL_FLOW_ERRORS = ["NEXT_NOT_FOUND", "NEXT_REDIRECT"] as const
 
 /** Expected user-facing auth outcomes (OAuth cancel, invalid callback state). */
-const EXPECTED_AUTH_ERRORS = ["CallbackRouteError", "InvalidCheck", "State cookie was missing"] as const
+const EXPECTED_AUTH_ERRORS = [
+    "CallbackRouteError",
+    "InvalidCheck",
+    "State cookie was missing"
+] as const
 
 /** Transient network failures surfaced by global handlers, not app bugs. */
 const TRANSIENT_NETWORK_ERRORS = [

--- a/src/lib/sentry/shared-options.ts
+++ b/src/lib/sentry/shared-options.ts
@@ -4,14 +4,18 @@ import type { ErrorEvent, EventHint } from "@sentry/nextjs"
 const NEXTJS_CONTROL_FLOW_ERRORS = ["NEXT_NOT_FOUND", "NEXT_REDIRECT"] as const
 
 /** Expected user-facing auth outcomes (OAuth cancel, invalid callback state). */
-const EXPECTED_AUTH_ERRORS = ["CallbackRouteError"] as const
+const EXPECTED_AUTH_ERRORS = ["CallbackRouteError", "InvalidCheck", "State cookie was missing"] as const
 
 /** Transient network failures surfaced by global handlers, not app bugs. */
 const TRANSIENT_NETWORK_ERRORS = [
     "Load failed",
     "Failed to fetch",
+    "fetch failed",
     "NetworkError when attempting to fetch resource"
 ] as const
+
+/** Dexie unavailable in private browsing / storage-blocked WebViews. */
+const DEXIE_ENVIRONMENT_ERRORS = ["OpenFailedError"] as const
 
 export function shouldDropSentryEvent(event: ErrorEvent, _hint?: EventHint): boolean {
     const values = event.exception?.values
@@ -24,7 +28,8 @@ export function shouldDropSentryEvent(event: ErrorEvent, _hint?: EventHint): boo
         return (
             NEXTJS_CONTROL_FLOW_ERRORS.some(error => message.includes(error)) ||
             EXPECTED_AUTH_ERRORS.some(error => message.includes(error)) ||
-            TRANSIENT_NETWORK_ERRORS.some(error => message.includes(error))
+            TRANSIENT_NETWORK_ERRORS.some(error => message.includes(error)) ||
+            DEXIE_ENVIRONMENT_ERRORS.some(error => message.includes(error))
         )
     })
 }
@@ -36,6 +41,7 @@ export const sentrySharedOptions = {
     ignoreErrors: [
         ...NEXTJS_CONTROL_FLOW_ERRORS,
         ...EXPECTED_AUTH_ERRORS,
-        ...TRANSIENT_NETWORK_ERRORS
+        ...TRANSIENT_NETWORK_ERRORS,
+        ...DEXIE_ENVIRONMENT_ERRORS
     ]
 }


### PR DESCRIPTION
## Summary
- Disable global `experimental.ppr` — root cause of `$RC` / parentNode / removeChild client errors on vanity, profile, and PGCR routes.
- Restore `/checkpoints` to use `notFound()` now that PPR is off (proper 404, no client RSC error).
- Remove per-segment `(profile)/layout.tsx` PPR opt-out (no longer needed).
- Extend Sentry filters: Auth.js `InvalidCheck`, server `fetch failed` / Turso timeouts, Dexie `OpenFailedError` (private browsing).

## Test plan
- [x] `bun run lint && bun run build`
- [ ] `curl -s -o /dev/null -w "%{http_code}" https://raidhub.io/checkpoints` → 404
- [ ] Vanity `/rosie`, profile, PGCR load without console errors
- [ ] Monitor Sentry for remaining unresolved issues

Fixes WEBSITE-11, WEBSITE-W, WEBSITE-12, WEBSITE-14, WEBSITE-15, WEBSITE-F, WEBSITE-B


Made with [Cursor](https://cursor.com)