### PR TITLE
Fix PGCR summary scrollbar for standard fireteams

### DIFF
--- a/src/components/pgcr/pgcr-players.tsx
+++ b/src/components/pgcr/pgcr-players.tsx
@@ -6,8 +6,8 @@ import {
     formatKdRelativeToAveragePercentage,
     formatTeamSharePercentage
 } from "~/lib/pgcr/formatting"
-import { cn } from "~/lib/tw"
 import { type PlayerStats } from "~/lib/pgcr/types"
+import { cn } from "~/lib/tw"
 import { type RaidHubInstanceExtended } from "~/services/raidhub/types"
 import { CardContent } from "~/shad/card"
 import { ScrollArea } from "~/shad/scroll-area"
@@ -197,11 +197,7 @@ export const PGCRPlayers = ({ data, mvp, playerMergedStats, sortScores }: PGCRPl
                 </div>
 
                 {sortScores.size > 12 ? (
-                    <ScrollArea
-                        className={cn(
-                            playerListClassName,
-                            "max-h-[calc(12*4rem+12*1px)]"
-                        )}>
+                    <ScrollArea className={cn(playerListClassName, "max-h-[calc(12*4rem+12*1px)]")}>
                         {playerList}
                     </ScrollArea>
                 ) : (

--- a/src/components/pgcr/pgcr-players.tsx
+++ b/src/components/pgcr/pgcr-players.tsx
@@ -6,6 +6,7 @@ import {
     formatKdRelativeToAveragePercentage,
     formatTeamSharePercentage
 } from "~/lib/pgcr/formatting"
+import { cn } from "~/lib/tw"
 import { type PlayerStats } from "~/lib/pgcr/types"
 import { type RaidHubInstanceExtended } from "~/services/raidhub/types"
 import { CardContent } from "~/shad/card"
@@ -171,6 +172,16 @@ export const PGCRPlayers = ({ data, mvp, playerMergedStats, sortScores }: PGCRPl
         }
     ]
 
+    const playerList = sortScores.map((_, id) => (
+        <Fragment key={id}>
+            <Separator className="bg-zinc-800" />
+            <PlayerRow player={data.players.find(p => p.playerInfo.membershipId === id)!} />
+        </Fragment>
+    ))
+
+    const playerListClassName =
+        "bg-background w-full overflow-x-auto border-x-1 border-b-1 border-zinc-800"
+
     return (
         <CardContent className="space-y-6 bg-black p-2 md:p-6">
             {/* Players Section */}
@@ -185,16 +196,17 @@ export const PGCRPlayers = ({ data, mvp, playerMergedStats, sortScores }: PGCRPl
                     <div className="text-center">Time</div>
                 </div>
 
-                <ScrollArea className="bg-background max-h-[600px] w-full overflow-x-auto border-x-1 border-b-1 border-zinc-800">
-                    {sortScores.map((_, id) => (
-                        <Fragment key={id}>
-                            <Separator className="bg-zinc-800" />
-                            <PlayerRow
-                                player={data.players.find(p => p.playerInfo.membershipId === id)!}
-                            />
-                        </Fragment>
-                    ))}
-                </ScrollArea>
+                {sortScores.size > 12 ? (
+                    <ScrollArea
+                        className={cn(
+                            playerListClassName,
+                            "max-h-[calc(12*4rem+12*1px)]"
+                        )}>
+                        {playerList}
+                    </ScrollArea>
+                ) : (
+                    <div className={playerListClassName}>{playerList}</div>
+                )}
             </div>
 
             {data.playerCount > 1 && (


### PR DESCRIPTION
## Summary
- Only wrap the PGCR player summary list in `ScrollArea` when there are more than 12 players.
- For 12 or fewer players, render a plain container so the roster expands naturally without a spurious scrollbar.
- When scrolling is needed, cap the viewport at 12 rows (`max-h-[calc(12*4rem+12*1px)]`) instead of the previous `600px` limit that could scroll as early as ~9 players.

## Test plan
- [ ] Open a PGCR with 6 players — summary list should show all rows with no vertical scrollbar.
- [ ] Open a PGCR with 12 players — all rows visible, no scrollbar.
- [ ] Open a PGCR with 13+ players — scrollbar appears and shows ~12 rows at a time.


Made with [Cursor](https://cursor.com)