### PR TITLE
Fix PGCR menu dropdown positioning

### DIFF
--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -34,20 +34,18 @@ const buttonVariants = cva(
     }
 )
 
-function Button({
-    className,
-    variant,
-    size,
-    asChild = false,
-    ...props
-}: React.ComponentProps<"button"> &
-    VariantProps<typeof buttonVariants> & {
-        asChild?: boolean
-    }) {
+const Button = React.forwardRef<
+    HTMLButtonElement,
+    React.ComponentProps<"button"> &
+        VariantProps<typeof buttonVariants> & {
+            asChild?: boolean
+        }
+>(({ className, variant, size, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : "button"
 
     return (
         <Comp
+            ref={ref}
             data-slot="button"
             className={cn(
                 "disabled:cursor-not-allowed",
@@ -56,6 +54,7 @@ function Button({
             {...props}
         />
     )
-}
+})
+Button.displayName = "Button"
 
 export { Button, buttonVariants }


### PR DESCRIPTION
## Summary
- Forward refs from the shared `Button` component so Radix `DropdownMenuTrigger asChild` can anchor the popover correctly.
- Fixes the PGCR header ⋮ menu opening off-screen (looked like a dead click).

## Test plan
- [x] `bunx tsc --noEmit`
- [x] Local PGCR page: click ⋮ → **Share** dropdown visible next to trigger
- [x] Screenshots: `assets/pgcr-menu-fix/pgcr-menu-open-localhost.png` (before/after vs prod in same folder)


Made with [Cursor](https://cursor.com)