### PR TITLE
Fix leaderboards RSC errors, LocaleManager, season lookup (batch 8)

### DIFF
--- a/src/app/leaderboards/LeaderboardSSR.tsx
+++ b/src/app/leaderboards/LeaderboardSSR.tsx
@@ -1,4 +1,4 @@
-import { notFound } from "next/navigation"
+import NotFound from "~/app/not-found"
 import { RaidHubError } from "~/services/raidhub/RaidHubError"
 import { getRaidHubApi } from "~/services/raidhub/common"
 import {
@@ -28,13 +28,17 @@ export const LeaderboardSSR = async <T extends RaidHubLeaderboardURL>(props: {
               ) as Promise<ResponseForLeaderboardURL<T>>
           ).catch(e => {
               if (e instanceof RaidHubError && e.errorCode === "PathValidationError") {
-                  notFound()
+                  return "not-found" as const
               } else {
                   console.error(e)
               }
               return null
           })
         : null
+
+    if (ssrData === "not-found") {
+        return <NotFound />
+    }
 
     return (
         <LeaderboardProvider

--- a/src/app/leaderboards/individual/[raid]/[category]/page.tsx
+++ b/src/app/leaderboards/individual/[raid]/[category]/page.tsx
@@ -1,4 +1,5 @@
 import { type Metadata } from "next"
+import NotFound from "~/app/not-found"
 import { LeaderboardSSR } from "~/app/leaderboards/LeaderboardSSR"
 import { CloudflareActivitySplash } from "~/components/CloudflareImage"
 import { baseMetadata } from "~/lib/metadata"
@@ -6,7 +7,7 @@ import { prefetchManifest } from "~/services/raidhub/prefetchRaidHubManifest"
 import { type PathParamsForLeaderboardURL } from "~/services/raidhub/types"
 import { Leaderboard } from "../../../Leaderboard"
 import { Splash } from "../../../LeaderboardSplashComponents"
-import { getRaidDefinition, tryGetRaidDefinition } from "../../../util"
+import { tryGetRaidDefinition } from "../../../util"
 
 export const dynamicParams = true
 export const revalidate = 900
@@ -56,7 +57,10 @@ export async function generateMetadata({ params }: DynamicParams): Promise<Metad
 
 export default async function Page({ params, searchParams }: DynamicParams) {
     const manifest = await prefetchManifest()
-    const definition = getRaidDefinition(params.raid, manifest)
+    const definition = tryGetRaidDefinition(params.raid, manifest)
+    if (!definition) {
+        return <NotFound />
+    }
     const categoryName = getCategoryName(params.category)
 
     return (

--- a/src/app/leaderboards/individual/[raid]/[category]/page.tsx
+++ b/src/app/leaderboards/individual/[raid]/[category]/page.tsx
@@ -1,6 +1,6 @@
 import { type Metadata } from "next"
-import NotFound from "~/app/not-found"
 import { LeaderboardSSR } from "~/app/leaderboards/LeaderboardSSR"
+import NotFound from "~/app/not-found"
 import { CloudflareActivitySplash } from "~/components/CloudflareImage"
 import { baseMetadata } from "~/lib/metadata"
 import { prefetchManifest } from "~/services/raidhub/prefetchRaidHubManifest"

--- a/src/app/leaderboards/individual/global/[category]/page.tsx
+++ b/src/app/leaderboards/individual/global/[category]/page.tsx
@@ -1,5 +1,5 @@
 import { type Metadata } from "next"
-import { notFound } from "next/navigation"
+import NotFound from "~/app/not-found"
 import { CloudflareStaticImage } from "~/components/CloudflareImage"
 import { baseMetadata } from "~/lib/metadata"
 import { type PathParamsForLeaderboardURL } from "~/services/raidhub/types"
@@ -26,14 +26,6 @@ const GLOBAL_CATEGORY_TITLES = {
 
 const tryGetCategoryTitle = (category: string) =>
     GLOBAL_CATEGORY_TITLES[category as CategoryParam] ?? null
-
-const getCategoryTitle = (category: CategoryParam) => {
-    const title = tryGetCategoryTitle(category)
-    if (!title) {
-        notFound()
-    }
-    return title
-}
 
 type DynamicParams = {
     params: {
@@ -65,7 +57,10 @@ export async function generateMetadata({ params }: DynamicParams): Promise<Metad
 const ENTRIES_PER_PAGE = 50
 
 export default async function Page({ params, searchParams }: DynamicParams) {
-    const categoryName = getCategoryTitle(params.category)
+    const categoryName = tryGetCategoryTitle(params.category)
+    if (!categoryName) {
+        return <NotFound />
+    }
 
     const apiParams = {
         category: params.category

--- a/src/app/leaderboards/individual/pantheon/[version]/[category]/page.tsx
+++ b/src/app/leaderboards/individual/pantheon/[version]/[category]/page.tsx
@@ -1,6 +1,6 @@
 import { type Metadata } from "next"
-import NotFound from "~/app/not-found"
 import { LeaderboardSSR } from "~/app/leaderboards/LeaderboardSSR"
+import NotFound from "~/app/not-found"
 import { CloudflareActivitySplash } from "~/components/CloudflareImage"
 import { findPantheonVersionByPath } from "~/lib/manifest/pantheon"
 import { baseMetadata } from "~/lib/metadata"

--- a/src/app/leaderboards/individual/pantheon/[version]/[category]/page.tsx
+++ b/src/app/leaderboards/individual/pantheon/[version]/[category]/page.tsx
@@ -1,5 +1,5 @@
 import { type Metadata } from "next"
-import { notFound } from "next/navigation"
+import NotFound from "~/app/not-found"
 import { LeaderboardSSR } from "~/app/leaderboards/LeaderboardSSR"
 import { CloudflareActivitySplash } from "~/components/CloudflareImage"
 import { findPantheonVersionByPath } from "~/lib/manifest/pantheon"
@@ -45,12 +45,7 @@ const getDefinitions = (
     params: PantheonVersionLeaderboardDynamicParams["params"],
     manifest: RaidHubManifestResponse
 ) => {
-    const definitions = tryGetDefinitions(params, manifest)
-    if (!definitions) {
-        return notFound()
-    }
-
-    return definitions
+    return tryGetDefinitions(params, manifest)
 }
 
 export async function generateMetadata({
@@ -94,7 +89,12 @@ export default async function Page({
     searchParams
 }: PantheonVersionLeaderboardDynamicParams) {
     const manifest = await prefetchManifest()
-    const { definition, activity, categoryName } = getDefinitions(params, manifest)
+    const definitions = getDefinitions(params, manifest)
+    if (!definitions) {
+        return <NotFound />
+    }
+
+    const { definition, activity, categoryName } = definitions
 
     return (
         <Leaderboard

--- a/src/app/leaderboards/team/[raid]/first/[version]/page.tsx
+++ b/src/app/leaderboards/team/[raid]/first/[version]/page.tsx
@@ -1,6 +1,6 @@
 import { type Metadata } from "next"
-import NotFound from "~/app/not-found"
 import { LeaderboardSSR } from "~/app/leaderboards/LeaderboardSSR"
+import NotFound from "~/app/not-found"
 import { CloudflareActivitySplash } from "~/components/CloudflareImage"
 import { findPantheonVersionByPath } from "~/lib/manifest/pantheon"
 import { baseMetadata } from "~/lib/metadata"

--- a/src/app/leaderboards/team/[raid]/first/[version]/page.tsx
+++ b/src/app/leaderboards/team/[raid]/first/[version]/page.tsx
@@ -1,5 +1,5 @@
 import { type Metadata } from "next"
-import { notFound } from "next/navigation"
+import NotFound from "~/app/not-found"
 import { LeaderboardSSR } from "~/app/leaderboards/LeaderboardSSR"
 import { CloudflareActivitySplash } from "~/components/CloudflareImage"
 import { findPantheonVersionByPath } from "~/lib/manifest/pantheon"
@@ -56,12 +56,7 @@ const tryGetDefinitions = (params: DynamicParams["params"], manifest: RaidHubMan
 }
 
 const getDefinitions = (params: DynamicParams["params"], manifest: RaidHubManifestResponse) => {
-    const definitions = tryGetDefinitions(params, manifest)
-    if (!definitions) {
-        return notFound()
-    }
-
-    return definitions
+    return tryGetDefinitions(params, manifest)
 }
 
 export async function generateMetadata({ params }: DynamicParams): Promise<Metadata> {
@@ -100,7 +95,13 @@ export async function generateMetadata({ params }: DynamicParams): Promise<Metad
 
 export default async function Page({ params, searchParams }: DynamicParams) {
     const manifest = await prefetchManifest()
-    const { version, activity, isPantheon } = getDefinitions(params, manifest)
+    const definitions = getDefinitions(params, manifest)
+    if (!definitions) {
+        return <NotFound />
+    }
+
+    const { version, activity, isPantheon } = definitions
+
     return (
         <Leaderboard
             heading={

--- a/src/app/leaderboards/team/[raid]/speedrun/[category]/page.tsx
+++ b/src/app/leaderboards/team/[raid]/speedrun/[category]/page.tsx
@@ -1,10 +1,10 @@
 import { type Metadata } from "next"
-import { notFound } from "next/navigation"
+import NotFound from "~/app/not-found"
 import { Leaderboard } from "~/app/leaderboards/Leaderboard"
 import { baseMetadata } from "~/lib/metadata"
 import { SpeedrunVariables, type RTABoardCategory } from "~/lib/speedrun/speedrun-com-mappings"
 import { prefetchManifest } from "~/services/raidhub/prefetchRaidHubManifest"
-import { getRaidDefinition, tryGetRaidDefinition } from "../../../../util"
+import { tryGetRaidDefinition } from "../../../../util"
 import { SpeedrunComBanner } from "./SpeedrunComBanner"
 import { SpeedrunComControls } from "./SpeedrunComControls"
 import { SpeedrunEntries } from "./SpeedrunEntries"
@@ -90,11 +90,16 @@ export async function generateMetadata({ params }: DynamicParams): Promise<Metad
 export default async function Page({ params }: DynamicParams) {
     const manifest = await prefetchManifest()
 
-    const raid = getRaidDefinition(params.raid, manifest)
+    const raid = tryGetRaidDefinition(params.raid, manifest)
+    if (!raid) {
+        return <NotFound />
+    }
     const category = params.category === "all" ? undefined : params.category
 
     const categoryId = SpeedrunVariables[raid.path]?.categoryId
-    if (!categoryId) return notFound()
+    if (!categoryId) {
+        return <NotFound />
+    }
 
     return (
         <Leaderboard

--- a/src/app/leaderboards/team/[raid]/speedrun/[category]/page.tsx
+++ b/src/app/leaderboards/team/[raid]/speedrun/[category]/page.tsx
@@ -1,6 +1,6 @@
 import { type Metadata } from "next"
-import NotFound from "~/app/not-found"
 import { Leaderboard } from "~/app/leaderboards/Leaderboard"
+import NotFound from "~/app/not-found"
 import { baseMetadata } from "~/lib/metadata"
 import { SpeedrunVariables, type RTABoardCategory } from "~/lib/speedrun/speedrun-com-mappings"
 import { prefetchManifest } from "~/services/raidhub/prefetchRaidHubManifest"

--- a/src/app/leaderboards/team/[raid]/worldfirst/page.tsx
+++ b/src/app/leaderboards/team/[raid]/worldfirst/page.tsx
@@ -1,4 +1,5 @@
 import { type Metadata } from "next"
+import NotFound from "~/app/not-found"
 import { LeaderboardSSR } from "~/app/leaderboards/LeaderboardSSR"
 import { CloudflareActivitySplash } from "~/components/CloudflareImage"
 import { baseMetadata } from "~/lib/metadata"
@@ -6,7 +7,7 @@ import { prefetchManifest } from "~/services/raidhub/prefetchRaidHubManifest"
 import { type PathParamsForLeaderboardURL } from "~/services/raidhub/types"
 import { Leaderboard } from "../../../Leaderboard"
 import { Splash } from "../../../LeaderboardSplashComponents"
-import { getRaidDefinition, tryGetRaidDefinition } from "../../../util"
+import { tryGetRaidDefinition } from "../../../util"
 
 export const dynamicParams = true
 export const revalidate = 900
@@ -48,7 +49,10 @@ export async function generateMetadata({ params }: DynamicParams): Promise<Metad
 
 export default async function Page({ params, searchParams }: DynamicParams) {
     const manifest = await prefetchManifest()
-    const definition = getRaidDefinition(params.raid, manifest)
+    const definition = tryGetRaidDefinition(params.raid, manifest)
+    if (!definition) {
+        return <NotFound />
+    }
 
     return (
         <Leaderboard

--- a/src/app/leaderboards/team/[raid]/worldfirst/page.tsx
+++ b/src/app/leaderboards/team/[raid]/worldfirst/page.tsx
@@ -1,6 +1,6 @@
 import { type Metadata } from "next"
-import NotFound from "~/app/not-found"
 import { LeaderboardSSR } from "~/app/leaderboards/LeaderboardSSR"
+import NotFound from "~/app/not-found"
 import { CloudflareActivitySplash } from "~/components/CloudflareImage"
 import { baseMetadata } from "~/lib/metadata"
 import { prefetchManifest } from "~/services/raidhub/prefetchRaidHubManifest"

--- a/src/app/leaderboards/team/custom/pantheon-community-race/page.tsx
+++ b/src/app/leaderboards/team/custom/pantheon-community-race/page.tsx
@@ -1,5 +1,5 @@
 import { type Metadata } from "next"
-import { notFound } from "next/navigation"
+import NotFound from "~/app/not-found"
 import { LeaderboardSSR } from "~/app/leaderboards/LeaderboardSSR"
 import { CloudflareActivitySplash } from "~/components/CloudflareImage"
 import { getActivePantheonIds, PANTHEON_COMMUNITY_RACE_VERSION_ID } from "~/lib/manifest/pantheon"
@@ -66,7 +66,7 @@ export default async function Page({ searchParams }: { searchParams: Record<stri
     const definitions = tryGetCommunityRaceDefinitions(manifest)
 
     if (!definitions) {
-        notFound()
+        return <NotFound />
     }
 
     const { activity, version } = definitions

--- a/src/app/leaderboards/team/custom/pantheon-community-race/page.tsx
+++ b/src/app/leaderboards/team/custom/pantheon-community-race/page.tsx
@@ -1,6 +1,6 @@
 import { type Metadata } from "next"
-import NotFound from "~/app/not-found"
 import { LeaderboardSSR } from "~/app/leaderboards/LeaderboardSSR"
+import NotFound from "~/app/not-found"
 import { CloudflareActivitySplash } from "~/components/CloudflareImage"
 import { getActivePantheonIds, PANTHEON_COMMUNITY_RACE_VERSION_ID } from "~/lib/manifest/pantheon"
 import { baseMetadata } from "~/lib/metadata"

--- a/src/app/leaderboards/util.ts
+++ b/src/app/leaderboards/util.ts
@@ -1,4 +1,3 @@
-import { notFound } from "next/navigation"
 import { type RaidHubManifestResponse } from "~/services/raidhub/types"
 
 export const tryGetRaidDefinition = (raid: string, manifest: RaidHubManifestResponse) => {
@@ -8,6 +7,4 @@ export const tryGetRaidDefinition = (raid: string, manifest: RaidHubManifestResp
     )
 }
 
-export const getRaidDefinition = (raid: string, manifest: RaidHubManifestResponse) => {
-    return tryGetRaidDefinition(raid, manifest) ?? notFound()
-}
+export const getRaidDefinition = tryGetRaidDefinition

--- a/src/components/profile/raids/finder/InstanceTable.tsx
+++ b/src/components/profile/raids/finder/InstanceTable.tsx
@@ -119,7 +119,7 @@ const InstanceTableRow = memo(
         const { getActivityString, getVersionString } = useRaidHubManifest()
         const { locale } = useLocale()
         const seasons = useSeasons()
-        const seasonName = seasons?.[instance.season - 1].displayProperties.name
+        const seasonName = seasons?.[instance.season - 1]?.displayProperties.name
 
         const attrs = useAtttributes(instance)
 

--- a/src/components/providers/LocaleManager.tsx
+++ b/src/components/providers/LocaleManager.tsx
@@ -30,7 +30,8 @@ const LanguageContext = createContext<
     | undefined
 >(undefined)
 
-export function LocaleManager({ children }: { children: ReactNode }) {
+export function LocaleManager(props: { children: ReactNode } | null) {
+    const children = props?.children ?? null
     const [locale, setLocale] = useState<string>("en-US")
     const [userAgent, setUserAgent] = useState(userAgentFromString(""))
     const [manifestLanguage, setManifestLanguage] = useState<DestinyManifestLanguage>("en")


### PR DESCRIPTION
## Summary
- **WEBSITE-5:** Replace `notFound()` with `<NotFound />` across all leaderboard routes (invalid categories like `powerRankings` were causing client RSC recoverable errors).
- **WEBSITE-1J:** Guard `LocaleManager` when React passes null props during error recovery.
- **WEBSITE-1K:** Optional-chain season lookup in `InstanceTable` when season index is out of bounds.
- **Sentry:** Restore batch-7 `shared-options` — only filter `NEXT_NOT_FOUND`/`NEXT_REDIRECT`, not network/auth noise.

## Test plan
- [ ] CI green
- [ ] `https://raidhub.io/leaderboards/individual/global/powerRankings` — 404 UI, no RSC error in console
- [ ] Home page loads without LocaleManager crash
- [ ] Profile finder tab with edge-case season data


Made with [Cursor](https://cursor.com)