### PR TITLE
Fix profile N+1 API calls and benign AbortErrors (batch 9)

### DIFF
--- a/src/components/profile/transitory/CurrentActivity.tsx
+++ b/src/components/profile/transitory/CurrentActivity.tsx
@@ -13,14 +13,12 @@ import { Container } from "~/components/__deprecated__/layout/Container"
 import { Flex } from "~/components/__deprecated__/layout/Flex"
 import { Grid } from "~/components/__deprecated__/layout/Grid"
 import { H4 } from "~/components/__deprecated__/typography/H4"
-import { useActivityDefinition, useActivityModeDefinition } from "~/hooks/dexie"
+import { useActivityDefinition, useActivityModeDefinition, useItemDefinition } from "~/hooks/dexie"
 import { useTimer } from "~/hooks/util/useTimer"
 import type { ProfileProps } from "~/lib/profile/types"
 import { useProfileLiveData, useProfileTransitory } from "~/services/bungie/hooks"
-import { useRaidHubResolvePlayer } from "~/services/raidhub/hooks"
 import { Card } from "~/shad/card"
-import { bungiePgcrImageUrl, bungieProfileIconUrl } from "~/util/destiny"
-import { getBungieDisplayName } from "~/util/destiny/getBungieDisplayName"
+import { bungieEmblemUrl, bungiePgcrImageUrl } from "~/util/destiny"
 import { Latest } from "./Latest"
 
 const commonTransitoryQuerySettings = {
@@ -167,27 +165,23 @@ const CurrentActivityCard = (props: {
     )
 }
 
-const PartyMember = ({ membershipId }: DestinyProfileTransitoryPartyMember) => {
-    const playerQuery = useRaidHubResolvePlayer(membershipId)
+const PartyMember = (pm: DestinyProfileTransitoryPartyMember) => {
+    const emblem = useItemDefinition(pm.emblemHash)
 
     return (
         <Container>
-            {playerQuery.data ? (
-                <Link href={`/profile/${playerQuery.data.membershipId}`} style={{ color: "unset" }}>
-                    <Flex $padding={0} $align="flex-start">
-                        <Image
-                            src={bungieProfileIconUrl(playerQuery.data.iconPath)}
-                            unoptimized
-                            width={32}
-                            height={32}
-                            alt="player icon"
-                        />
-                        <span>{getBungieDisplayName(playerQuery.data)}</span>
-                    </Flex>
-                </Link>
-            ) : (
-                membershipId
-            )}
+            <Link href={`/profile/${pm.membershipId}`} style={{ color: "unset" }}>
+                <Flex $padding={0} $align="flex-start">
+                    <Image
+                        src={bungieEmblemUrl(emblem)}
+                        unoptimized
+                        width={32}
+                        height={32}
+                        alt={pm.displayName}
+                    />
+                    <span>{pm.displayName}</span>
+                </Flex>
+            </Link>
         </Container>
     )
 }

--- a/src/components/providers/QueryManager.tsx
+++ b/src/components/providers/QueryManager.tsx
@@ -6,7 +6,7 @@ import { httpLink, loggerLink, type TRPCLink } from "@trpc/client"
 import { observable } from "@trpc/server/observable"
 import { useState } from "react"
 import superjson from "superjson"
-import { captureClientException } from "~/lib/sentry/capture"
+import { captureClientException, isBenignClientAbort } from "~/lib/sentry/capture"
 import { type AppRouter } from "~/lib/server/trpc"
 import { trpc } from "~/lib/trpc"
 
@@ -24,11 +24,7 @@ const sentryLink: TRPCLink<AppRouter> = () => {
                     observer.next(value)
                 },
                 error(error) {
-                    if (error instanceof DOMException && error.name === "AbortError") {
-                        observer.error(error)
-                        return
-                    }
-                    if (error instanceof Error && error.name === "AbortError") {
+                    if (isBenignClientAbort(error)) {
                         observer.error(error)
                         return
                     }
@@ -61,11 +57,7 @@ export function QueryManager(props: { children: React.ReactNode }) {
             new QueryClient({
                 queryCache: new QueryCache({
                     onError: (error, query) => {
-                        // Cancelled queries (navigation/unmount) — not application errors.
-                        if (error instanceof DOMException && error.name === "AbortError") {
-                            return
-                        }
-                        if (error instanceof Error && error.name === "AbortError") {
+                        if (isBenignClientAbort(error)) {
                             return
                         }
 

--- a/src/hooks/useActivityClusterGuardians.ts
+++ b/src/hooks/useActivityClusterGuardians.ts
@@ -11,10 +11,11 @@ export const useActivityClusterGuardians = (
     const leadActivity = cluster.activities[0]
     const skip = !leadActivity || leadActivity.playerCount > 50
 
-    const instanceIds = useMemo(
-        () => getActivityClusterInstanceIds(cluster.activities.map(a => a.instanceId)),
-        [cluster.activities]
-    )
+    const instanceIds = useMemo(() => {
+        const ids = getActivityClusterInstanceIds(cluster.activities.map(a => a.instanceId))
+        // One instance is enough for teammate chips; avoids N parallel /instance calls per cluster.
+        return ids.slice(0, 1)
+    }, [cluster.activities])
 
     const queries = useRaidHubInstanceList(skip ? [] : instanceIds)
 

--- a/src/lib/sentry/capture.ts
+++ b/src/lib/sentry/capture.ts
@@ -30,7 +30,19 @@ const HANDLED_RAIDHUB_ERROR_CODES = new Set<RaidHubErrorCode>([
 /** tRPC codes mapped to handled HTTP semantics — same dedupe rationale as above. */
 const HANDLED_TRPC_ERROR_CODES = new Set(["NOT_FOUND", "UNAUTHORIZED", "FORBIDDEN", "BAD_REQUEST"])
 
+/** Expected aborts (navigation cancel, user cleared site data / IndexedDB). */
+export function isBenignClientAbort(error: unknown): boolean {
+    if (error instanceof DOMException && error.name === "AbortError") {
+        return true
+    }
+
+    return error instanceof Error && error.name === "AbortError"
+}
+
 function shouldCaptureError(error: unknown): boolean {
+    if (isBenignClientAbort(error)) {
+        return false
+    }
     if (error instanceof RaidHubError && HANDLED_RAIDHUB_ERROR_CODES.has(error.errorCode)) {
         return false
     }


### PR DESCRIPTION
## Summary
- **WEBSITE-1E**: Stop N+1 `/player/*/basic` calls — `CurrentActivity` party members now use Bungie transitory data (`displayName`, `emblemHash`) instead of one `useRaidHubResolvePlayer` per fireteam member.
- **WEBSITE-19**: Reduce `/instance/*` N+1 on history tab — fetch one representative instance per activity cluster for guardian chips.
- **WEBSITE-1H**: Skip all benign `AbortError` in client Sentry capture (Dexie DB cleared by user, query cancel on navigation) via shared `isBenignClientAbort`.

## Test plan
- [ ] Open a profile with an active fireteam — party members show names/emblems without extra basic API calls
- [ ] History tab — teammate chips still render on session clusters
- [ ] CI green (format, lint, tsc, Vercel)

Fixes WEBSITE-1E, WEBSITE-19, WEBSITE-1H

Made with [Cursor](https://cursor.com)