### PR TITLE
Fix clan lookup errors and benign client storage noise (batch 10)

### DIFF
--- a/src/components/profile/user/UserCard.tsx
+++ b/src/components/profile/user/UserCard.tsx
@@ -37,14 +37,21 @@ export function UserCard() {
         }
     )
 
-    const bungieProfileQuery = useLinkedProfiles(
-        {
-            membershipId: props.destinyMembershipId
-        },
-        {
-            select: res => res.bnetMembership
-        }
-    )
+    const linkedProfilesQuery = useLinkedProfiles({
+        membershipId: props.destinyMembershipId
+    })
+
+    const bungieProfileQuery = {
+        data: linkedProfilesQuery.data?.bnetMembership
+    }
+
+    const clanMembershipType = useMemo(() => {
+        const match = linkedProfilesQuery.data?.profiles.find(
+            profile => profile.membershipId === props.destinyMembershipId
+        )
+
+        return match?.membershipType ?? props.destinyMembershipType
+    }, [linkedProfilesQuery.data, props.destinyMembershipId, props.destinyMembershipType])
 
     const { data: raidHubUser } = trpc.profile.getUnique.useQuery(
         {
@@ -95,7 +102,7 @@ export function UserCard() {
         )
 
     const { data: clan } = useClansForMember(
-        { membershipId: props.destinyMembershipId, membershipType: props.destinyMembershipType },
+        { membershipId: props.destinyMembershipId, membershipType: clanMembershipType },
         {
             staleTime: 10 * 60000,
             select: res => (res.results.length > 0 ? res.results[0].group : null)

--- a/src/components/providers/QueryManager.tsx
+++ b/src/components/providers/QueryManager.tsx
@@ -126,7 +126,9 @@ export function QueryManager(props: { children: React.ReactNode }) {
             process.env.NODE_ENV === 'development', so you don't need to worry
              about excluding them during a production build. */}
             <trpc.Provider client={trpcClient} queryClient={queryClient}>
-                <ReactQueryDevtools initialIsOpen={false} />
+                {process.env.NODE_ENV === "development" ? (
+                    <ReactQueryDevtools initialIsOpen={false} />
+                ) : null}
                 {props.children}
             </trpc.Provider>
         </QueryClientProvider>

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -5,7 +5,8 @@ import {
     getSentryRelease,
     getTracesSampleRate
 } from "./lib/sentry/env"
-import { sentrySharedOptions } from "./lib/sentry/shared-options"
+import { shouldDropGlobalBenignEvent } from "./lib/sentry/capture"
+import { sentrySharedOptions, shouldDropSentryEvent } from "./lib/sentry/shared-options"
 
 const dsn = getSentryDsnForClient()
 
@@ -16,7 +17,18 @@ if (dsn) {
         release: getSentryRelease(),
         tracesSampleRate: getTracesSampleRate(),
         debug: process.env.NODE_ENV !== "production",
-        ...sentrySharedOptions
+        ...sentrySharedOptions,
+        beforeSend(event, hint) {
+            if (shouldDropSentryEvent(event, hint)) {
+                return null
+            }
+
+            if (shouldDropGlobalBenignEvent(event)) {
+                return null
+            }
+
+            return event
+        }
     })
 }
 

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,11 +1,11 @@
 import * as Sentry from "@sentry/nextjs"
+import { shouldDropGlobalBenignEvent } from "./lib/sentry/capture"
 import {
     getSentryDsnForClient,
     getSentryEnvironment,
     getSentryRelease,
     getTracesSampleRate
 } from "./lib/sentry/env"
-import { shouldDropGlobalBenignEvent } from "./lib/sentry/capture"
 import { sentrySharedOptions, shouldDropSentryEvent } from "./lib/sentry/shared-options"
 
 const dsn = getSentryDsnForClient()

--- a/src/lib/sentry/capture.ts
+++ b/src/lib/sentry/capture.ts
@@ -1,9 +1,9 @@
-import * as Sentry from "@sentry/nextjs"
 import type { ErrorEvent } from "@sentry/nextjs"
+import * as Sentry from "@sentry/nextjs"
 import { BungiePlatformError } from "~/models/BungieAPIError"
+import BaseBungieClient from "~/services/bungie/BungieClient"
 import { RaidHubError } from "~/services/raidhub/RaidHubError"
 import type { RaidHubErrorCode } from "~/services/raidhub/types"
-import BaseBungieClient from "~/services/bungie/BungieClient"
 import { buildSentryContext, type SentryCaptureContext } from "./context"
 import { getSentryDsnForServer } from "./env"
 

--- a/src/lib/sentry/capture.ts
+++ b/src/lib/sentry/capture.ts
@@ -1,6 +1,9 @@
 import * as Sentry from "@sentry/nextjs"
+import type { ErrorEvent } from "@sentry/nextjs"
+import { BungiePlatformError } from "~/models/BungieAPIError"
 import { RaidHubError } from "~/services/raidhub/RaidHubError"
 import type { RaidHubErrorCode } from "~/services/raidhub/types"
+import BaseBungieClient from "~/services/bungie/BungieClient"
 import { buildSentryContext, type SentryCaptureContext } from "./context"
 import { getSentryDsnForServer } from "./env"
 
@@ -36,11 +39,102 @@ export function isBenignClientAbort(error: unknown): boolean {
         return true
     }
 
-    return error instanceof Error && error.name === "AbortError"
+    if (error instanceof Error && error.name === "AbortError") {
+        return true
+    }
+
+    const message = getErrorMessage(error)
+    return message.includes("AbortError") && message.includes("Database deleted")
+}
+
+function getErrorMessage(error: unknown): string {
+    if (error instanceof Error) {
+        const parts = [error.message]
+        if (error.cause instanceof Error) {
+            parts.push(error.cause.message)
+        }
+        return parts.join(" ")
+    }
+
+    return typeof error === "string" ? error : String(error)
+}
+
+function isBenignClientStorageError(error: unknown): boolean {
+    const message = getErrorMessage(error)
+    return (
+        message.includes("OpenFailedError") ||
+        message.includes("Database deleted by request of the user")
+    )
+}
+
+function isBenignDataCloneError(error: unknown): boolean {
+    if (error instanceof DOMException && error.name === "DataCloneError") {
+        return true
+    }
+
+    return error instanceof Error && error.name === "DataCloneError"
+}
+
+function isExpectedBungiePlatformError(error: unknown): boolean {
+    return (
+        error instanceof BungiePlatformError &&
+        BaseBungieClient.ExpectedErrorCodes.has(error.ErrorCode)
+    )
+}
+
+function isTransientTrpcHtmlError(error: unknown): boolean {
+    const message = getErrorMessage(error)
+    return message.includes("Unexpected token '<'") || message.includes("<!DOCTYPE")
+}
+
+function getEventErrorText(event: ErrorEvent): string {
+    return (
+        event.exception?.values
+            ?.map(value => [value.type, value.value].filter(Boolean).join(": "))
+            .join(" ") ?? ""
+    )
+}
+
+/** Benign errors caught by Sentry's global unhandled-rejection handler (not captureClientException). */
+export function shouldDropGlobalBenignEvent(event: ErrorEvent): boolean {
+    const text = getEventErrorText(event)
+
+    if (
+        text.includes("Database deleted by request of the user") ||
+        text.includes("OpenFailedError")
+    ) {
+        return true
+    }
+
+    if (text.includes("AbortError") && text.includes("Database deleted")) {
+        return true
+    }
+
+    if (text.includes("DataCloneError") || text.includes("The object can not be cloned")) {
+        return true
+    }
+
+    return false
 }
 
 function shouldCaptureError(error: unknown): boolean {
     if (isBenignClientAbort(error)) {
+        return false
+    }
+
+    if (isBenignClientStorageError(error)) {
+        return false
+    }
+
+    if (isBenignDataCloneError(error)) {
+        return false
+    }
+
+    if (isExpectedBungiePlatformError(error)) {
+        return false
+    }
+
+    if (isTransientTrpcHtmlError(error)) {
         return false
     }
     if (error instanceof RaidHubError && HANDLED_RAIDHUB_ERROR_CODES.has(error.errorCode)) {

--- a/src/services/bungie/BungieClient.ts
+++ b/src/services/bungie/BungieClient.ts
@@ -87,6 +87,7 @@ export default abstract class BaseBungieClient implements BungieClientProtocol {
 
     static readonly ExpectedErrorCodes = new Set<PlatformErrorCodes>([
         5, // SystemDisabled
+        18, // InvalidParameters — bad membership/type combos on optional lookups (e.g. clans)
         686, // ClanNotFound
         1653 // PGCRNotFound
     ])

--- a/src/services/bungie/hooks/useClansForMember.ts
+++ b/src/services/bungie/hooks/useClansForMember.ts
@@ -5,8 +5,8 @@ import type {
     GetGroupsForMemberResponse,
     GroupsForMemberFilter
 } from "bungie-net-core/models"
-import { BungiePlatformError } from "~/models/BungieAPIError"
 import { useBungieClient } from "~/components/providers/session/BungieClientProvider"
+import { BungiePlatformError } from "~/models/BungieAPIError"
 import BaseBungieClient from "~/services/bungie/BungieClient"
 
 const emptyGroupsForMemberResponse: GetGroupsForMemberResponse = {

--- a/src/services/bungie/hooks/useClansForMember.ts
+++ b/src/services/bungie/hooks/useClansForMember.ts
@@ -5,7 +5,19 @@ import type {
     GetGroupsForMemberResponse,
     GroupsForMemberFilter
 } from "bungie-net-core/models"
+import { BungiePlatformError } from "~/models/BungieAPIError"
 import { useBungieClient } from "~/components/providers/session/BungieClientProvider"
+import BaseBungieClient from "~/services/bungie/BungieClient"
+
+const emptyGroupsForMemberResponse: GetGroupsForMemberResponse = {
+    areAllMembershipsInactive: {},
+    results: [],
+    totalResults: 0,
+    hasMore: false,
+    query: { itemsPerPage: 0, currentPage: 0, requestContinuationToken: "" },
+    replacementContinuationToken: "",
+    useTotalResults: false
+}
 
 export const useClansForMember = <T = GetGroupsForMemberResponse>(
     {
@@ -25,12 +37,24 @@ export const useClansForMember = <T = GetGroupsForMemberResponse>(
 
     return useQuery({
         queryKey: ["bungie", "clan for member", filter, params] as const,
-        queryFn: ({ queryKey }) =>
-            getGroupsForMember(bungieClient, {
-                ...queryKey[3],
-                filter: queryKey[2],
-                groupType: 1 // GroupType.Clan
-            }).then(res => res.Response),
+        queryFn: async ({ queryKey }) => {
+            try {
+                return await getGroupsForMember(bungieClient, {
+                    ...queryKey[3],
+                    filter: queryKey[2],
+                    groupType: 1 // GroupType.Clan
+                }).then(res => res.Response)
+            } catch (error) {
+                if (
+                    error instanceof BungiePlatformError &&
+                    BaseBungieClient.ExpectedErrorCodes.has(error.ErrorCode)
+                ) {
+                    return emptyGroupsForMemberResponse
+                }
+
+                throw error
+            }
+        },
         ...opts
     })
 }


### PR DESCRIPTION
## Summary
- **WEBSITE-1F**: Clan lookup uses linked-profile `membershipType`; `InvalidParameters` and other expected Bungie codes return empty results instead of erroring to Sentry.
- **WEBSITE-1G/1H/13**: Global unhandled-rejection noise from Dexie (DB cleared, OpenFailed in in-app browsers) dropped via `shouldDropGlobalBenignEvent` in client instrumentation — `shared-options.ts` still NEXT_* only.
- **WEBSITE-18**: React Query Devtools gated to `development` only (DataCloneError from postMessage in prod browsers).
- **WEBSITE-1B**: Transient tRPC HTML responses skipped in `captureClientException` (Vercel error page instead of JSON).

## Test plan
- [ ] Profile with clan shows clan tag; profile without clan shows no error
- [ ] CI green
- [ ] Post-deploy: 1F/1G/1H/13/18/1B stop appearing in unresolved

Fixes WEBSITE-1F, WEBSITE-1G, WEBSITE-1H, WEBSITE-13, WEBSITE-18, WEBSITE-1B

Made with [Cursor](https://cursor.com)