### PR TITLE
Reduce ambient network and auth Sentry noise (batch 11)

### DIFF
--- a/src/components/providers/DestinyManifestManager.tsx
+++ b/src/components/providers/DestinyManifestManager.tsx
@@ -98,6 +98,7 @@ const DestinyManifestManager = ({ children }: { children: ReactNode }) => {
     const queryState = useQuery({
         queryKey: ["bungie", "manifest", manifestLanguage],
         queryFn: () => getDestinyManifest(client).then(res => res.Response),
+        meta: { sentryCapture: false },
         suspense: false,
         enabled: manifestVersion !== undefined,
         staleTime: 3600_000, // 1 hour

--- a/src/components/providers/QueryManager.tsx
+++ b/src/components/providers/QueryManager.tsx
@@ -6,7 +6,7 @@ import { httpLink, loggerLink, type TRPCLink } from "@trpc/client"
 import { observable } from "@trpc/server/observable"
 import { useState } from "react"
 import superjson from "superjson"
-import { captureClientException, isBenignClientAbort } from "~/lib/sentry/capture"
+import { captureClientException, isBenignClientAbort, shouldSkipQueryCacheCapture } from "~/lib/sentry/capture"
 import { type AppRouter } from "~/lib/server/trpc"
 import { trpc } from "~/lib/trpc"
 
@@ -58,6 +58,10 @@ export function QueryManager(props: { children: React.ReactNode }) {
                 queryCache: new QueryCache({
                     onError: (error, query) => {
                         if (isBenignClientAbort(error)) {
+                            return
+                        }
+
+                        if (shouldSkipQueryCacheCapture(error, query)) {
                             return
                         }
 

--- a/src/components/providers/QueryManager.tsx
+++ b/src/components/providers/QueryManager.tsx
@@ -6,7 +6,11 @@ import { httpLink, loggerLink, type TRPCLink } from "@trpc/client"
 import { observable } from "@trpc/server/observable"
 import { useState } from "react"
 import superjson from "superjson"
-import { captureClientException, isBenignClientAbort, shouldSkipQueryCacheCapture } from "~/lib/sentry/capture"
+import {
+    captureClientException,
+    isBenignClientAbort,
+    shouldSkipQueryCacheCapture
+} from "~/lib/sentry/capture"
 import { type AppRouter } from "~/lib/server/trpc"
 import { trpc } from "~/lib/trpc"
 

--- a/src/lib/sentry/capture.ts
+++ b/src/lib/sentry/capture.ts
@@ -91,7 +91,11 @@ function isTransientTrpcHtmlError(error: unknown): boolean {
 export function isAmbientNetworkError(error: unknown): boolean {
     const message = getErrorMessage(error)
 
-    if (!(error instanceof TypeError) && !message.includes("Failed to fetch") && !message.includes("Load failed")) {
+    if (
+        !(error instanceof TypeError) &&
+        !message.includes("Failed to fetch") &&
+        !message.includes("Load failed")
+    ) {
         return false
     }
 

--- a/src/lib/sentry/capture.ts
+++ b/src/lib/sentry/capture.ts
@@ -87,6 +87,36 @@ function isTransientTrpcHtmlError(error: unknown): boolean {
     return message.includes("Unexpected token '<'") || message.includes("<!DOCTYPE")
 }
 
+/** Client-side connectivity blips (Safari "Load failed", fetch abort offline). */
+export function isAmbientNetworkError(error: unknown): boolean {
+    const message = getErrorMessage(error)
+
+    if (!(error instanceof TypeError) && !message.includes("Failed to fetch") && !message.includes("Load failed")) {
+        return false
+    }
+
+    return (
+        message === "Load failed" ||
+        message === "Failed to fetch" ||
+        message.includes("Failed to fetch (") ||
+        message.includes("Load failed (") ||
+        message.includes("NetworkError") ||
+        message.includes("network error")
+    )
+}
+
+export function shouldSkipQueryCacheCapture(
+    error: unknown,
+    query: { state: { data: unknown }; meta?: Record<string, unknown> | undefined }
+): boolean {
+    if (query.meta?.sentryCapture === false) {
+        return true
+    }
+
+    // Refetch-on-focus/reconnect failed but stale data is still shown — not an app bug.
+    return isAmbientNetworkError(error) && query.state.data !== undefined
+}
+
 function getEventErrorText(event: ErrorEvent): string {
     return (
         event.exception?.values
@@ -111,6 +141,22 @@ export function shouldDropGlobalBenignEvent(event: ErrorEvent): boolean {
     }
 
     if (text.includes("DataCloneError") || text.includes("The object can not be cloned")) {
+        return true
+    }
+
+    const hasAppStackFrame = event.exception?.values?.some(value =>
+        value.stacktrace?.frames?.some(
+            frame => typeof frame.filename === "string" && frame.filename.includes("/src/")
+        )
+    )
+
+    // Unhandled rejections with no app frames — typically connectivity, not debuggable bugs.
+    if (
+        !hasAppStackFrame &&
+        (text.includes("Failed to fetch") ||
+            text.includes("Load failed") ||
+            text.includes("NetworkError"))
+    ) {
         return true
     }
 

--- a/src/lib/server/auth/index.ts
+++ b/src/lib/server/auth/index.ts
@@ -50,6 +50,11 @@ const {
                     message: err.message,
                     cause: err.cause
                 })
+
+                if (authContext.tags.auth_error_class === "likely_user_action") {
+                    return
+                }
+
                 captureServerException(err, {
                     tags: {
                         area: "nextauth",

--- a/src/services/bungie/hooks/useCommonSettings.ts
+++ b/src/services/bungie/hooks/useCommonSettings.ts
@@ -14,6 +14,7 @@ export const useCommonSettings = <T = CoreSettingsConfiguration>(
     return useQuery({
         queryKey: ["bungie", "platform-settings"] as const,
         queryFn: () => getCommonSettings(bungieClient).then(res => res.Response),
+        meta: { sentryCapture: false },
         ...opts
     })
 }

--- a/src/services/bungie/hooks/useGlobalAlerts.ts
+++ b/src/services/bungie/hooks/useGlobalAlerts.ts
@@ -23,6 +23,7 @@ export const useGlobalAlerts = <T = GlobalAlert[]>(
         queryKey: ["bungie", "global-alerts", params] as const,
         queryFn: ({ queryKey }) =>
             getGlobalAlerts(bungieClient, queryKey[2]).then(res => res.Response),
+        meta: { sentryCapture: false },
         ...opts
     })
 }


### PR DESCRIPTION
## Summary
- **WEBSITE-10/17/16/1M/1P/1Q**: Skip react-query Sentry capture when a refetch fails but stale cached data is still shown (focus/reconnect connectivity blips). Initial load failures with no cache still report.
- **Status probes**: `useCommonSettings`, `useGlobalAlerts`, and manifest download queries marked `meta.sentryCapture: false` — optional banners/overlays handle failures in UI.
- **WEBSITE-1N**: Drop global unhandled-rejection events with network messages and no app stack frames.
- **WEBSITE-1C**: Skip Sentry for NextAuth errors classified as `likely_user_action` (access denied, OAuth cancel).

Network errors on first fetch (no cached data) remain visible with enrichment.

## Test plan
- [ ] Profile/PGCR load offline then reconnect — no Sentry spam on refocus if data cached
- [ ] OAuth cancel does not create Sentry issue
- [ ] CI green

Fixes WEBSITE-10, WEBSITE-17, WEBSITE-16, WEBSITE-1M, WEBSITE-1P, WEBSITE-1Q, WEBSITE-1N, WEBSITE-1C

Made with [Cursor](https://cursor.com)