### PR TITLE
Optional Bungie queries + auth signup hardening (batch 12)

### DIFF
--- a/src/lib/sentry/context.ts
+++ b/src/lib/sentry/context.ts
@@ -183,19 +183,20 @@ export function classifyAuthError(err: { name?: string; message?: string; cause?
     extra: Record<string, unknown>
 } {
     const name = err.name ?? ""
-    const message = err.message ?? ""
+    const combinedText = getAuthErrorText(err)
 
     const likelyUserAction =
         name === "CallbackRouteError" ||
         name === "AccessDenied" ||
         name === "OAuthCallbackError" ||
         name === "OAuthSignInError" ||
-        message.includes("State cookie was missing") ||
-        message.includes("access_denied") ||
-        message.includes("errors.authjs.dev")
+        combinedText.includes("State cookie was missing") ||
+        combinedText.includes("access_denied") ||
+        combinedText.includes("errors.authjs.dev") ||
+        combinedText.includes("No primary Destiny membership found")
 
     const extra: Record<string, unknown> = {
-        auth_error_message: message
+        auth_error_message: err.message ?? ""
     }
 
     if (err.cause instanceof Error) {
@@ -212,4 +213,23 @@ export function classifyAuthError(err: { name?: string; message?: string; cause?
         },
         extra
     }
+}
+
+function getAuthErrorText(err: { message?: string; cause?: unknown }): string {
+    const parts: string[] = []
+    if (err.message) {
+        parts.push(err.message)
+    }
+
+    let cause: unknown = err.cause
+    for (let depth = 0; depth < 4 && cause; depth++) {
+        if (cause instanceof Error) {
+            parts.push(cause.message)
+            cause = cause.cause
+        } else {
+            break
+        }
+    }
+
+    return parts.join(" ")
 }

--- a/src/lib/server/auth/adapter.ts
+++ b/src/lib/server/auth/adapter.ts
@@ -39,7 +39,9 @@ export const PrismaAdapter = (prisma: PrismaClientWithExtensions): Adapter => ({
             }
         })
 
-        await updateDestinyProfiles(input.userMembershipData)
+        await updateDestinyProfiles(input.userMembershipData).catch(error => {
+            console.warn("Failed to sync Destiny profiles during signup", error)
+        })
 
         return {
             ...user,

--- a/src/services/bungie/hooks/useProfileLiveData.ts
+++ b/src/services/bungie/hooks/useProfileLiveData.ts
@@ -37,6 +37,7 @@ export const useProfileLiveData = <T = UseLiveProfileQueryData>(
                     204 /*CharacterActivities*/, 205 /*CharacterEquipment*/, 305 /*ItemSockets*/
                 ]
             }).then(res => res.Response),
+        meta: { sentryCapture: false },
         ...opts,
         enabled: isClient && (opts?.enabled ?? true)
     })

--- a/src/services/bungie/hooks/useProfileTransitory.ts
+++ b/src/services/bungie/hooks/useProfileTransitory.ts
@@ -21,6 +21,7 @@ export const useProfileTransitory = <T = DestinyProfileResponse<[1000]>>(
                 ...params,
                 components: [1000]
             }).then(res => res.Response),
+        meta: { sentryCapture: false },
         ...opts,
         enabled: isClient && (opts?.enabled ?? true)
     })


### PR DESCRIPTION
## Summary
- **WEBSITE-1S**: `useProfileLiveData` + `useProfileTransitory` → `meta.sentryCapture: false` (CurrentActivity hides on failure).
- **WEBSITE-1R**: Manifest already marked in batch 11; no new events expected post-deploy.
- **WEBSITE-1D**: Signup no longer throws when `updateDestinyProfiles` fails (e.g. no applicable memberships). Auth classifier walks error cause chain for `errors.authjs.dev` / adapter edge cases.

## Test plan
- [ ] Profile loads; in-game card absent when Bungie unreachable (no Sentry)
- [ ] Bungie OAuth signup with edge-case account still completes
- [ ] CI green

Fixes WEBSITE-1S, WEBSITE-1D

Made with [Cursor](https://cursor.com)