### PR TITLE
Skip optional probe queries in Sentry by query key (batch 13)

### DIFF
--- a/src/components/providers/DestinyManifestManager.tsx
+++ b/src/components/providers/DestinyManifestManager.tsx
@@ -59,6 +59,7 @@ const DestinyManifestManager = ({ children }: { children: ReactNode }) => {
     const { mutateAsync: storeManifest, ...mutationState } = useMutation({
         mutationFn: (args: Parameters<typeof dexieDB.updateDefinitions>[1]) =>
             dexieDB.updateDefinitions(seedCache, args),
+        meta: { sentryCapture: false },
         onSuccess: setManifestVersion,
         onError: async (err: Error | Error[]) => {
             const errors = Array.isArray(err) ? err : [err]

--- a/src/components/providers/QueryManager.tsx
+++ b/src/components/providers/QueryManager.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { QueryCache, QueryClient, QueryClientProvider } from "@tanstack/react-query"
+import { MutationCache, QueryCache, QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
 import { httpLink, loggerLink, type TRPCLink } from "@trpc/client"
 import { observable } from "@trpc/server/observable"
@@ -9,6 +9,7 @@ import superjson from "superjson"
 import {
     captureClientException,
     isBenignClientAbort,
+    shouldSkipMutationCapture,
     shouldSkipQueryCacheCapture
 } from "~/lib/sentry/capture"
 import { type AppRouter } from "~/lib/server/trpc"
@@ -89,6 +90,17 @@ export function QueryManager(props: { children: React.ReactNode }) {
                         })
                     }
                 }),
+                mutationCache: new MutationCache({
+                    onError: (error, _variables, _context, mutation) => {
+                        if (shouldSkipMutationCapture(mutation)) {
+                            return
+                        }
+
+                        captureClientException(error, {
+                            tags: { capture_source: "react-query-mutation" }
+                        })
+                    }
+                }),
                 defaultOptions: {
                     queries: {
                         staleTime: 60000,
@@ -99,13 +111,6 @@ export function QueryManager(props: { children: React.ReactNode }) {
                         suspense: false,
                         useErrorBoundary: false,
                         retryDelay: failureCount => Math.min(2 ** failureCount * 1000, 30_000)
-                    },
-                    mutations: {
-                        onError: error => {
-                            captureClientException(error, {
-                                tags: { capture_source: "react-query-mutation" }
-                            })
-                        }
                     }
                 }
             })

--- a/src/lib/sentry/capture.ts
+++ b/src/lib/sentry/capture.ts
@@ -109,11 +109,44 @@ export function isAmbientNetworkError(error: unknown): boolean {
     )
 }
 
+/** Queries whose failures are handled in UI (overlays, optional cards) — not app bugs. */
+const OPTIONAL_PROBE_QUERY_PREFIXES: readonly (readonly string[])[] = [
+    ["bungie", "manifest"],
+    ["bungie", "platform-settings"],
+    ["bungie", "global-alerts"],
+    ["bungie", "profile", "live data"],
+    ["bungie", "profile", "transitory"]
+]
+
+function isOptionalProbeQueryKey(queryKey: unknown): boolean {
+    if (!Array.isArray(queryKey)) {
+        return false
+    }
+
+    return OPTIONAL_PROBE_QUERY_PREFIXES.some(prefix =>
+        prefix.every((segment, index) => queryKey[index] === segment)
+    )
+}
+
+export function shouldSkipMutationCapture(mutation: {
+    meta?: Record<string, unknown> | undefined
+}): boolean {
+    return mutation.meta?.sentryCapture === false
+}
+
 export function shouldSkipQueryCacheCapture(
     error: unknown,
-    query: { state: { data: unknown }; meta?: Record<string, unknown> | undefined }
+    query: {
+        queryKey: unknown
+        state: { data: unknown }
+        meta?: Record<string, unknown> | undefined
+    }
 ): boolean {
     if (query.meta?.sentryCapture === false) {
+        return true
+    }
+
+    if (isOptionalProbeQueryKey(query.queryKey)) {
         return true
     }
 


### PR DESCRIPTION
## Summary
- **WEBSITE-1R**: Manifest fetch failures still reported despite `meta.sentryCapture: false` on pre-deploy builds — add query-key allowlist for optional probes (manifest, status banner, live/transitory profile data).
- Manifest Dexie store mutation → `meta.sentryCapture: false` + `MutationCache` handler.

First-load failures on **required** data queries (profile, activities, etc.) still report.

## Test plan
- [ ] Homepage/profile with Bungie blocked — manifest overlay shows, no Sentry event
- [ ] CI green

Fixes WEBSITE-1R

Made with [Cursor](https://cursor.com)