### PR TITLE
Overnight Sentry batch 15: tooltips, lazy guardians

### DIFF
--- a/src/components/pgcr/pgcr-date.tsx
+++ b/src/components/pgcr/pgcr-date.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { usePGCRContext } from "~/hooks/pgcr/ClientStateManager"
-import { Tooltip, TooltipContent, TooltipTrigger } from "~/shad/tooltip"
+import { formatTimeRangeTitle } from "~/lib/pgcr/time-range-title"
 
 export const PGCRDate = () => {
     const { data } = usePGCRContext()
@@ -17,36 +17,11 @@ export const PGCRDate = () => {
 
     return (
         <div className="flex items-center gap-2">
-            <Tooltip>
-                <TooltipTrigger asChild>
-                    <p className="flex items-center gap-1 text-sm text-zinc-400">{dateString}</p>
-                </TooltipTrigger>
-                <TimeRangeTooltip startDate={startDate} endDate={endDate} />
-            </Tooltip>
+            <p
+                className="flex items-center gap-1 text-sm text-zinc-400"
+                title={formatTimeRangeTitle(startDate, endDate)}>
+                {dateString}
+            </p>
         </div>
-    )
-}
-
-export const TimeRangeTooltip = ({ startDate, endDate }: { startDate: Date; endDate: Date }) => {
-    const tooltipStartTime = startDate.toLocaleString(undefined, {
-        timeZoneName: "short"
-    })
-    const tooltipEndTime = endDate.toLocaleString(undefined, {
-        timeZoneName: "short"
-    })
-
-    return (
-        <TooltipContent side="bottom" align="start">
-            <div className="text-xs">
-                <p>
-                    <strong>Started: </strong>
-                    {tooltipStartTime}
-                </p>
-                <p>
-                    <strong>Ended: </strong>
-                    {tooltipEndTime}
-                </p>
-            </div>
-        </TooltipContent>
     )
 }

--- a/src/components/pgcr/pgcr-feats.tsx
+++ b/src/components/pgcr/pgcr-feats.tsx
@@ -2,7 +2,6 @@
 
 import Image from "next/image"
 import { usePGCRContext } from "~/hooks/pgcr/ClientStateManager"
-import { Tooltip, TooltipContent, TooltipTrigger } from "~/shad/tooltip"
 import { bungieIconUrl } from "~/util/destiny"
 
 export const PGCRFeats = () => {
@@ -12,28 +11,19 @@ export const PGCRFeats = () => {
         !!selectedFeats.length && (
             <div className="flex gap-1 md:gap-2">
                 {selectedFeats.map(feat => (
-                    <Tooltip key={feat.hash}>
-                        <TooltipTrigger asChild>
-                            <span className="inline-flex">
-                                <Image
-                                    src={bungieIconUrl(feat.iconPath)}
-                                    alt={feat.name}
-                                    width={60}
-                                    height={60}
-                                    className="size-10"
-                                    unoptimized
-                                />
-                            </span>
-                        </TooltipTrigger>
-                        <TooltipContent side="bottom" align="start">
-                            <div className="text-xs">
-                                <p>
-                                    <strong>{feat.name}</strong>
-                                </p>
-                                <p>{feat.shortDescription}</p>
-                            </div>
-                        </TooltipContent>
-                    </Tooltip>
+                    <span
+                        key={feat.hash}
+                        title={`${feat.name} — ${feat.shortDescription}`}
+                        className="inline-flex">
+                        <Image
+                            src={bungieIconUrl(feat.iconPath)}
+                            alt={feat.name}
+                            width={60}
+                            height={60}
+                            className="size-10"
+                            unoptimized
+                        />
+                    </span>
                 ))}
             </div>
         )

--- a/src/components/pgcr/pgcr-header.tsx
+++ b/src/components/pgcr/pgcr-header.tsx
@@ -3,12 +3,12 @@
 import { CheckCircle, Clock, MapPin, TriangleAlert, Users, XCircle } from "lucide-react"
 import { usePGCRContext } from "~/hooks/pgcr/ClientStateManager"
 import { getPgcrDisplayTitle } from "~/lib/pgcr/formatting"
+import { formatTimeRangeTitle } from "~/lib/pgcr/time-range-title"
 import { cn } from "~/lib/tw"
 import { Badge } from "~/shad/badge"
 import { CardHeader } from "~/shad/card"
-import { Tooltip, TooltipContent, TooltipTrigger } from "~/shad/tooltip"
 import { secondsToHMS } from "~/util/presentation/formatting"
-import { PGCRDate, TimeRangeTooltip } from "./pgcr-date"
+import { PGCRDate } from "./pgcr-date"
 import { PGCRFeats } from "./pgcr-feats"
 import { PGCRHeaderBackground } from "./pgcr-header-bg"
 import { PGCRMenu } from "./pgcr-menu"
@@ -16,6 +16,10 @@ import { PGCRTags } from "./pgcr-tags"
 
 export const PGCRHeader = () => {
     const { data } = usePGCRContext()
+    const startDate = new Date(data.dateStarted)
+    const endDate = new Date(data.dateCompleted)
+    const completedCount = data.players.reduce((acc, player) => +player.completed + acc, 0)
+
     return (
         <PGCRHeaderBackground activityId={data.activityId} versionId={data.versionId}>
             <div className="absolute inset-0 bg-gradient-to-r from-black/70 via-black/50 to-black/30 backdrop-blur-[2px]" />
@@ -23,19 +27,11 @@ export const PGCRHeader = () => {
                 <div className="inline-flex gap-4">
                     <PGCRDate />
                     {data.isBlacklisted && (
-                        <Tooltip>
-                            <TooltipTrigger asChild>
-                                <div className="flex-1 rounded-full bg-amber-600/20">
-                                    <TriangleAlert className="size-8 p-1.5 text-amber-400" />
-                                </div>
-                            </TooltipTrigger>
-                            <TooltipContent side="top" align="center">
-                                <p className="max-w-[30ch] text-center">
-                                    This instance is blacklisted from appearing in leaderboards or
-                                    tags on the participant&apos;s profiles
-                                </p>
-                            </TooltipContent>
-                        </Tooltip>
+                        <div
+                            title="This instance is blacklisted from appearing in leaderboards or tags on the participant's profiles"
+                            className="flex-1 rounded-full bg-amber-600/20">
+                            <TriangleAlert className="size-8 p-1.5 text-amber-400" />
+                        </div>
                     )}
                 </div>
                 <div className="flex flex-wrap items-center gap-2">
@@ -43,53 +39,40 @@ export const PGCRHeader = () => {
                         {getPgcrDisplayTitle(data.metadata)}
                     </h1>
 
-                    {/* Cleared status badge */}
-                    <Tooltip>
-                        <TooltipTrigger asChild>
-                            <div
-                                className={cn(
-                                    "rounded-full p-1",
-                                    data.completed
-                                        ? "bg-green-500/30 text-green-400"
-                                        : "bg-red-500/30 text-red-400"
-                                )}>
-                                {data.completed ? (
-                                    <CheckCircle className="h-7 w-7 p-1" />
-                                ) : (
-                                    <XCircle className="h-7 w-7 p-1" />
-                                )}
-                            </div>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                            {data.completed ? "Activity Cleared" : "Activity Not Cleared"}
-                        </TooltipContent>
-                    </Tooltip>
+                    <div
+                        title={data.completed ? "Activity Cleared" : "Activity Not Cleared"}
+                        className={cn(
+                            "rounded-full p-1",
+                            data.completed
+                                ? "bg-green-500/30 text-green-400"
+                                : "bg-red-500/30 text-red-400"
+                        )}>
+                        {data.completed ? (
+                            <CheckCircle className="h-7 w-7 p-1" />
+                        ) : (
+                            <XCircle className="h-7 w-7 p-1" />
+                        )}
+                    </div>
 
-                    {/* Checkpoint flag */}
                     {!data.fresh && (
-                        <Tooltip>
-                            <TooltipTrigger asChild>
-                                <div
-                                    className={cn(
-                                        "rounded-full p-1",
-                                        data.fresh === null
-                                            ? "bg-purple-500/30 text-purple-400"
-                                            : "bg-pink-500/30 text-pink-400"
-                                    )}>
-                                    <MapPin className="h-7 w-7 p-1" />
-                                </div>
-                            </TooltipTrigger>
-                            <TooltipContent>
-                                {data.fresh === null
+                        <div
+                            title={
+                                data.fresh === null
                                     ? "This activity may or may not be a checkpoint"
-                                    : "This activity was started from a checkpoint"}
-                            </TooltipContent>
-                        </Tooltip>
+                                    : "This activity was started from a checkpoint"
+                            }
+                            className={cn(
+                                "rounded-full p-1",
+                                data.fresh === null
+                                    ? "bg-purple-500/30 text-purple-400"
+                                    : "bg-pink-500/30 text-pink-400"
+                            )}>
+                            <MapPin className="h-7 w-7 p-1" />
+                        </div>
                     )}
                 </div>
 
                 <div className="flex flex-wrap items-center gap-3">
-                    {/* Difficulty badge */}
                     {data.metadata.isRaid && (
                         <Badge
                             variant="secondary"
@@ -105,42 +88,26 @@ export const PGCRHeader = () => {
                         </Badge>
                     )}
 
-                    {/* Tags & Feats */}
                     <PGCRTags />
                     <PGCRFeats />
                 </div>
                 <div className="mt-4 flex items-center justify-center gap-4">
-                    <Tooltip>
-                        <TooltipTrigger asChild>
-                            <div className="flex items-center gap-2 text-zinc-300">
-                                <Clock className="h-3 w-3 md:h-4 md:w-4" />
-                                <span className="text-xs md:text-sm">
-                                    {secondsToHMS(data.duration, false)}
-                                </span>
-                            </div>
-                        </TooltipTrigger>
-                        <TimeRangeTooltip
-                            startDate={new Date(data.dateStarted)}
-                            endDate={new Date(data.dateCompleted)}
-                        />
-                    </Tooltip>
+                    <div
+                        title={formatTimeRangeTitle(startDate, endDate)}
+                        className="flex items-center gap-2 text-zinc-300">
+                        <Clock className="h-3 w-3 md:h-4 md:w-4" />
+                        <span className="text-xs md:text-sm">
+                            {secondsToHMS(data.duration, false)}
+                        </span>
+                    </div>
                     {(data.playerCount > 3 || !data.completed) && (
-                        <Tooltip>
-                            <TooltipTrigger asChild>
-                                <Badge
-                                    variant="outline"
-                                    className="bg-background/70 flex items-center gap-1 border-zinc-700 whitespace-nowrap">
-                                    <Users className="h-3 w-3" />
-                                    <span>{data.playerCount} Players</span>
-                                </Badge>
-                            </TooltipTrigger>
-                            <TooltipContent side="bottom">
-                                {`${data.players.reduce(
-                                    (acc, player) => +player.completed + acc,
-                                    0
-                                )} of ${data.playerCount} players completed the activity`}
-                            </TooltipContent>
-                        </Tooltip>
+                        <Badge
+                            variant="outline"
+                            title={`${completedCount} of ${data.playerCount} players completed the activity`}
+                            className="bg-background/70 flex items-center gap-1 border-zinc-700 whitespace-nowrap">
+                            <Users className="h-3 w-3" />
+                            <span>{data.playerCount} Players</span>
+                        </Badge>
                     )}
                 </div>
 

--- a/src/components/pgcr/pgcr-multi-timeline.tsx
+++ b/src/components/pgcr/pgcr-multi-timeline.tsx
@@ -5,7 +5,6 @@ import { useCallback, useMemo } from "react"
 import { type MultiInstanceTimelineSegment } from "~/lib/multi/multi-types"
 import { cn } from "~/lib/tw"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "~/shad/card"
-import { Tooltip, TooltipContent, TooltipTrigger } from "~/shad/tooltip"
 import { secondsToHMS } from "~/util/presentation/formatting"
 
 export const PGCRMultiTimeline = ({ segments }: { segments: MultiInstanceTimelineSegment[] }) => {
@@ -59,29 +58,26 @@ export const PGCRMultiTimeline = ({ segments }: { segments: MultiInstanceTimelin
                         const endPct = getRatio(d.end) * 100
 
                         return (
-                            <Tooltip key={d.instanceId}>
-                                <TooltipTrigger asChild>
-                                    <Link
-                                        className={cn(
-                                            "bg-raidhub/75 absolute top-0 h-full border-x",
-                                            d.completed && "bg-green-500"
-                                        )}
-                                        style={{
-                                            left: `${startPct}%`,
-                                            width: `${endPct - startPct}%`
-                                        }}
-                                        href={`/pgcr/${d.instanceId}`}
-                                        target="_blank"
-                                    />
-                                </TooltipTrigger>
-                                <TooltipContent>
-                                    <h4 className="font-bold">{`Instance #${i + 1}: ${d.instanceId}`}</h4>
-                                    <div className="mb-2 font-semibold">{`${d.activityName}: ${d.versionName}`}</div>
-                                    <div>{`Started: ${d.start.toLocaleString()}`}</div>
-                                    <div>{`Ended: ${d.end.toLocaleString()}`}</div>
-                                    <div>{`Duration: ${secondsToHMS(d.duration, false)}`}</div>
-                                </TooltipContent>
-                            </Tooltip>
+                            <Link
+                                key={d.instanceId}
+                                title={[
+                                    `Instance #${i + 1}: ${d.instanceId}`,
+                                    `${d.activityName}: ${d.versionName}`,
+                                    `Started: ${d.start.toLocaleString()}`,
+                                    `Ended: ${d.end.toLocaleString()}`,
+                                    `Duration: ${secondsToHMS(d.duration, false)}`
+                                ].join("\n")}
+                                className={cn(
+                                    "bg-raidhub/75 absolute top-0 h-full border-x",
+                                    d.completed && "bg-green-500"
+                                )}
+                                style={{
+                                    left: `${startPct}%`,
+                                    width: `${endPct - startPct}%`
+                                }}
+                                href={`/pgcr/${d.instanceId}`}
+                                target="_blank"
+                            />
                         )
                     })}
                 </div>

--- a/src/components/pgcr/pgcr-weapons.tsx
+++ b/src/components/pgcr/pgcr-weapons.tsx
@@ -7,7 +7,6 @@ import { useMemo } from "react"
 import { usePGCRContext } from "~/hooks/pgcr/ClientStateManager"
 import { type PlayerStats } from "~/lib/pgcr/types"
 import { cn } from "~/lib/tw"
-import { Tooltip, TooltipContent, TooltipTrigger } from "~/shad/tooltip"
 import { bungieItemUrl, getBungieDisplayName } from "~/util/destiny"
 
 interface WeaponData {
@@ -170,25 +169,20 @@ const WeaponRow = ({
                     {weaponName}
                 </Link>
                 {showUsers ? (
-                    <Tooltip>
-                        <TooltipTrigger asChild>
-                            <span className="text-[10px] text-zinc-500">
-                                {users.size} player{users.size !== 1 ? "s" : ""}
-                            </span>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                            {Array.from(users).map(id => (
-                                <div key={id}>
-                                    {getBungieDisplayName(
-                                        data.players.find(
-                                            player => player.playerInfo.membershipId === id
-                                        )!.playerInfo,
-                                        { excludeCode: true }
-                                    )}
-                                </div>
-                            ))}
-                        </TooltipContent>
-                    </Tooltip>
+                    <span
+                        title={Array.from(users)
+                            .map(id =>
+                                getBungieDisplayName(
+                                    data.players.find(
+                                        player => player.playerInfo.membershipId === id
+                                    )!.playerInfo,
+                                    { excludeCode: true }
+                                )
+                            )
+                            .join(", ")}
+                        className="text-[10px] text-zinc-500">
+                        {users.size} player{users.size !== 1 ? "s" : ""}
+                    </span>
                 ) : (
                     <span className="text-[10px] text-zinc-500">
                         {precisionPct.toFixed(0)}% precision

--- a/src/components/pgcr/player-details-panel.tsx
+++ b/src/components/pgcr/player-details-panel.tsx
@@ -16,7 +16,6 @@ import { cn } from "~/lib/tw"
 import { type RaidHubInstancePlayerExtended } from "~/services/raidhub/types"
 import { Avatar, AvatarFallback, AvatarImage } from "~/shad/avatar"
 import { Button } from "~/shad/button"
-import { Tooltip, TooltipContent, TooltipTrigger } from "~/shad/tooltip"
 import { bungieBannerEmblemUrl, bungieIconUrl, getBungieDisplayName } from "~/util/destiny"
 import { round } from "~/util/math"
 import { secondsToHMS } from "~/util/presentation/formatting"
@@ -61,12 +60,9 @@ const StatStrip = ({ stats }: { stats: StatCell[] }) => (
             }
 
             return (
-                <Tooltip key={stat.label}>
-                    <TooltipTrigger asChild>
-                        <div>{cell}</div>
-                    </TooltipTrigger>
-                    <TooltipContent>{stat.tooltip}</TooltipContent>
-                </Tooltip>
+                <div key={stat.label} title={stat.tooltip}>
+                    {cell}
+                </div>
             )
         })}
     </div>
@@ -326,20 +322,16 @@ const PlayerDetailsPanel = ({ player, onClose }: PlayerDetailsPanelProps) => {
                                     </span>
                                 )}
                             </h2>
-                            <Tooltip>
-                                <TooltipTrigger asChild>
-                                    <Button
-                                        variant="ghost"
-                                        size="icon"
-                                        className="size-6 shrink-0 rounded-full hover:bg-zinc-800"
-                                        asChild>
-                                        <Link href={`/profile/${player.playerInfo.membershipId}`}>
-                                            <LinkIcon className="size-3.5" />
-                                        </Link>
-                                    </Button>
-                                </TooltipTrigger>
-                                <TooltipContent>View Profile</TooltipContent>
-                            </Tooltip>
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                title="View Profile"
+                                className="size-6 shrink-0 rounded-full hover:bg-zinc-800"
+                                asChild>
+                                <Link href={`/profile/${player.playerInfo.membershipId}`}>
+                                    <LinkIcon className="size-3.5" />
+                                </Link>
+                            </Button>
                         </div>
                         <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
                             {mvp === player.playerInfo.membershipId && (

--- a/src/components/profile/raids/history/ClusterGuardians.tsx
+++ b/src/components/profile/raids/history/ClusterGuardians.tsx
@@ -1,6 +1,8 @@
 "use client"
 
+import { useRef } from "react"
 import { useActivityClusterGuardians } from "~/hooks/useActivityClusterGuardians"
+import { useIsVisible } from "~/hooks/util/useIsVisible"
 import { CLUSTER_GUARDIAN_DISPLAY_LIMIT } from "~/lib/activity/guardians"
 import { type ActivityCluster } from "~/lib/activity/sessions"
 import { cn } from "~/lib/tw"
@@ -15,22 +17,27 @@ export const ClusterGuardians = ({
     profileMembershipIds: readonly string[]
     className?: string
 }) => {
+    const containerRef = useRef<HTMLDivElement>(null)
+    const isVisible = useIsVisible(containerRef, { rootMargin: "240px" })
     const { guardians, isLoading, skip } = useActivityClusterGuardians(
         cluster,
-        profileMembershipIds
+        profileMembershipIds,
+        { enabled: isVisible }
     )
 
     const teammates = guardians?.filter(guardian => !guardian.isProfilePlayer) ?? []
 
-    if (skip || isLoading || teammates.length === 0) {
-        return null
+    if (!isVisible || skip || isLoading || teammates.length === 0) {
+        return <div ref={containerRef} className={className} />
     }
 
     const visible = teammates.slice(0, CLUSTER_GUARDIAN_DISPLAY_LIMIT)
     const overflow = teammates.length - visible.length
 
     return (
-        <div className={cn("flex min-w-0 flex-wrap items-center gap-1.5", className)}>
+        <div
+            ref={containerRef}
+            className={cn("flex min-w-0 flex-wrap items-center gap-1.5", className)}>
             {visible.map(guardian => (
                 <GuardianChip key={guardian.playerInfo.membershipId} guardian={guardian} />
             ))}

--- a/src/components/profile/user/CommunityProfiles..tsx
+++ b/src/components/profile/user/CommunityProfiles..tsx
@@ -3,7 +3,6 @@ import Image from "next/image"
 import Link from "next/link"
 import { usePageProps } from "~/components/PageWrapper"
 import { type ProfileProps } from "~/lib/profile/types"
-import { Tooltip, TooltipContent, TooltipTrigger } from "~/shad/tooltip"
 
 const memTypeToString: Record<number, string> = {
     1: "xb",
@@ -67,18 +66,17 @@ export function CommunityProfiles() {
 
 const Profile = ({ title, url, icon }: { title: string; url: string; icon: string }) => {
     return (
-        <Tooltip>
-            <TooltipTrigger asChild>
-                <Link href={url} target="_blank" className="relative aspect-square w-5 md:w-7">
-                    <Image src={icon} alt={title} fill unoptimized />
-                </Link>
-            </TooltipTrigger>
-            <TooltipContent>
-                <div className="flex items-center gap-2">
-                    {title}
-                    <ExternalLink className="size-4" />
-                </div>
-            </TooltipContent>
-        </Tooltip>
+        <Link
+            href={url}
+            target="_blank"
+            title={title}
+            aria-label={title}
+            className="relative aspect-square w-5 md:w-7">
+            <Image src={icon} alt={title} fill unoptimized />
+            <span className="sr-only">
+                {title}
+                <ExternalLink className="size-4" aria-hidden />
+            </span>
+        </Link>
     )
 }

--- a/src/components/profile/user/ProfileBadge.tsx
+++ b/src/components/profile/user/ProfileBadge.tsx
@@ -1,5 +1,4 @@
 import { CloudflareIcon } from "~/components/CloudflareImage"
-import { Tooltip, TooltipContent, TooltipTrigger } from "~/shad/tooltip"
 
 export function ProfileBadge(badge: {
     id: string
@@ -9,25 +8,14 @@ export function ProfileBadge(badge: {
     size: number
 }) {
     return (
-        <Tooltip>
-            <TooltipTrigger asChild>
-                <span className="inline-flex">
-                    <CloudflareIcon
-                        path={badge.icon}
-                        alt={badge.name}
-                        width={32}
-                        height={32}
-                        objectFit="contain"
-                    />
-                </span>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-                <p>
-                    <b>{badge.name}</b>
-                    <br />
-                    {badge.description}
-                </p>
-            </TooltipContent>
-        </Tooltip>
+        <span className="inline-flex" title={`${badge.name} — ${badge.description}`}>
+            <CloudflareIcon
+                path={badge.icon}
+                alt={badge.name}
+                width={32}
+                height={32}
+                objectFit="contain"
+            />
+        </span>
     )
 }

--- a/src/components/profile/user/UserCard.tsx
+++ b/src/components/profile/user/UserCard.tsx
@@ -14,7 +14,6 @@ import { useRaidHubPlayer, useRaidHubResolvePlayer } from "~/services/raidhub/ho
 import { type RaidHubPlayerInfo } from "~/services/raidhub/types"
 import { Avatar, AvatarImage } from "~/shad/avatar"
 import { Card, CardHeader } from "~/shad/card"
-import { Tooltip, TooltipContent, TooltipTrigger } from "~/shad/tooltip"
 import { bungieBannerEmblemUrl, bungieProfileIconUrl } from "~/util/destiny"
 import { fixClanName } from "~/util/destiny/fixClanName"
 import { getBungieDisplayName } from "~/util/destiny/getBungieDisplayName"
@@ -154,15 +153,12 @@ export function UserCard() {
                     <div className="flex flex-col items-start gap-1 p-1">
                         <h1 className="flex items-center gap-2 text-2xl">
                             {isPrivate && (
-                                <Tooltip>
-                                    <TooltipTrigger asChild>
-                                        <PrivacyLockIcon className="text-raidhub" />
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                        The owner of this profile has chosen to keep their activity
-                                        history private.
-                                    </TooltipContent>
-                                </Tooltip>
+                                <span
+                                    title="The owner of this profile has chosen to keep their activity history private."
+                                    aria-label="Private profile"
+                                    className="inline-flex">
+                                    <PrivacyLockIcon className="text-raidhub" />
+                                </span>
                             )}
                             <span>
                                 {displayName}

--- a/src/hooks/useActivityClusterGuardians.ts
+++ b/src/hooks/useActivityClusterGuardians.ts
@@ -5,11 +5,13 @@ import { useRaidHubInstanceList } from "~/services/raidhub/hooks"
 
 export const useActivityClusterGuardians = (
     cluster: ActivityCluster,
-    profileMembershipIds: readonly string[] = []
+    profileMembershipIds: readonly string[] = [],
+    opts?: { enabled?: boolean }
 ) => {
     const profileIds = useMemo(() => new Set(profileMembershipIds), [profileMembershipIds])
     const leadActivity = cluster.activities[0]
     const skip = !leadActivity || leadActivity.playerCount > 50
+    const enabled = opts?.enabled ?? true
 
     const instanceIds = useMemo(() => {
         const ids = getActivityClusterInstanceIds(cluster.activities.map(a => a.instanceId))
@@ -17,7 +19,7 @@ export const useActivityClusterGuardians = (
         return ids.slice(0, 1)
     }, [cluster.activities])
 
-    const queries = useRaidHubInstanceList(skip ? [] : instanceIds)
+    const queries = useRaidHubInstanceList(skip || !enabled ? [] : instanceIds)
 
     return useMemo(() => {
         if (skip) {

--- a/src/lib/pgcr/time-range-title.ts
+++ b/src/lib/pgcr/time-range-title.ts
@@ -1,0 +1,5 @@
+export function formatTimeRangeTitle(startDate: Date, endDate: Date): string {
+    const started = startDate.toLocaleString(undefined, { timeZoneName: "short" })
+    const ended = endDate.toLocaleString(undefined, { timeZoneName: "short" })
+    return `Started: ${started} · Ended: ${ended}`
+}

--- a/src/lib/sentry/policy.ts
+++ b/src/lib/sentry/policy.ts
@@ -88,6 +88,21 @@ function isBenignDataCloneError(error: unknown): boolean {
     return error instanceof Error && error.name === "DataCloneError"
 }
 
+function isBenignDomMutationError(error: unknown): boolean {
+    const message = getErrorMessage(error)
+    const name =
+        error instanceof DOMException ? error.name : error instanceof Error ? error.name : ""
+
+    return (
+        name === "NotFoundError" &&
+        (message.includes("removeChild") || message.includes("The object can not be found here"))
+    )
+}
+
+function isExtensionInjectedError(error: unknown): boolean {
+    return /_0x[0-9a-f]+/i.test(getErrorMessage(error))
+}
+
 function isExpectedBungiePlatformError(error: unknown): boolean {
     return (
         error instanceof BungiePlatformError &&
@@ -150,6 +165,14 @@ export function shouldSkipCapture(error: unknown): boolean {
     }
 
     if (isBenignDataCloneError(error)) {
+        return true
+    }
+
+    if (isBenignDomMutationError(error)) {
+        return true
+    }
+
+    if (isExtensionInjectedError(error)) {
         return true
     }
 
@@ -237,6 +260,10 @@ export function shouldDropClientEvent(event: ErrorEvent): boolean {
     }
 
     if (text.includes("DataCloneError") || text.includes("The object can not be cloned")) {
+        return true
+    }
+
+    if (text.includes("removeChild") || text.includes("The object can not be found here")) {
         return true
     }
 


### PR DESCRIPTION
## Summary
- **WEBSITE-C / WEBSITE-21 / WEBSITE-23**: Remove Radix tooltips from profile (`UserCard`, `ProfileBadge`, `CommunityProfiles`) and remaining PGCR surfaces — use native `title` to stop `removeChild` hydration teardown errors
- **WEBSITE-19**: Lazy-load history teammate chips — `/instance/*` fetches only when a cluster scrolls into view
- **Policy**: Skip Radix DOM teardown (`removeChild`, object-not-found) and extension `_0x` injection errors in `captureClientException` + global `beforeSend`

## Unchanged / ambient (no code fix)
- `WEBSITE-20/24` server `fetch failed` on profile SSR
- `WEBSITE-1W/1X/1Y` offline/network blips
- `WEBSITE-1T` iOS 15 SyntaxError on leaderboard chunk
- `WEBSITE-1Z/25` Dexie DB closed (policy should drop post-deploy)
- `WEBSITE-22` SecurityError on `/` (single event)

## Test plan
- [x] `bunx tsc --noEmit`
- [x] `next lint`
- [ ] Profile: hover badges, community icons, private lock — native tooltips
- [ ] PGCR: hover feats/header stats/player panel — native tooltips
- [ ] History tab: guardian chips appear when scrolling clusters into view
- [ ] Sentry soak after deploy


Made with [Cursor](https://cursor.com)