### PR TITLE
Fix Sentry root causes: profile select, Turso retries, Dexie recovery

### DIFF
--- a/package.json
+++ b/package.json
@@ -167,6 +167,13 @@
             "@typescript-eslint/no-misused-promises": "off"
         }
     },
+    "browserslist": [
+        "chrome >= 87",
+        "firefox >= 78",
+        "safari >= 14",
+        "ios >= 14",
+        "edge >= 88"
+    ],
     "postcss": {
         "plugins": {
             "@tailwindcss/postcss": {}

--- a/src/components/overlays/ManifestStatusOverlay.tsx
+++ b/src/components/overlays/ManifestStatusOverlay.tsx
@@ -14,7 +14,7 @@ export const ManifestStatusOverlay = (
           }
         | {
               status: "dexie-error"
-              error: Error | Error[]
+              error: Error | Error[] | AggregateError
           }
 ) => {
     const [isErrorHidden, setIsErrorHidden] = useState(false)
@@ -71,7 +71,17 @@ export const ManifestStatusOverlay = (
                             <ErrorMesssage>
                                 <div style={{ marginBottom: "1rem" }}>
                                     <b>Error:</b> Failed to save manifest definitions:{" "}
-                                    {Array.isArray(props.error) ? (
+                                    {props.error instanceof AggregateError ? (
+                                        <ul>
+                                            {props.error.errors
+                                                .slice(0, 3)
+                                                .map((e, idx) => (
+                                                    <li key={idx}>
+                                                        {e instanceof Error ? e.message : String(e)}
+                                                    </li>
+                                                ))}
+                                        </ul>
+                                    ) : Array.isArray(props.error) ? (
                                         <ul>
                                             {props.error.slice(0, 3).map((e, idx) => (
                                                 <li key={idx}>{e.message}</li>

--- a/src/components/overlays/ManifestStatusOverlay.tsx
+++ b/src/components/overlays/ManifestStatusOverlay.tsx
@@ -73,13 +73,11 @@ export const ManifestStatusOverlay = (
                                     <b>Error:</b> Failed to save manifest definitions:{" "}
                                     {props.error instanceof AggregateError ? (
                                         <ul>
-                                            {props.error.errors
-                                                .slice(0, 3)
-                                                .map((e, idx) => (
-                                                    <li key={idx}>
-                                                        {e instanceof Error ? e.message : String(e)}
-                                                    </li>
-                                                ))}
+                                            {props.error.errors.slice(0, 3).map((e, idx) => (
+                                                <li key={idx}>
+                                                    {e instanceof Error ? e.message : String(e)}
+                                                </li>
+                                            ))}
                                         </ul>
                                     ) : Array.isArray(props.error) ? (
                                         <ul>

--- a/src/components/profile/raids/FilterSelect.tsx
+++ b/src/components/profile/raids/FilterSelect.tsx
@@ -1,45 +1,35 @@
 import { FilterPresets } from "~/lib/profile/filters/activityFilters"
-import {
-    Select,
-    SelectContent,
-    SelectGroup,
-    SelectItem,
-    SelectLabel,
-    SelectTrigger,
-    SelectValue
-} from "~/shad/select"
+import { cn } from "~/lib/tw"
 import { useFilterContext } from "./FilterContext"
 
 export const FilterSelect = () => {
     const { setFilter, filter } = useFilterContext()
+
     return (
-        <div className="relative">
-            <Select
-                value={filter?.id}
-                onValueChange={value => {
-                    const data = FilterPresets[value as keyof typeof FilterPresets]
-                    if (filter) {
-                        setFilter({
-                            id: value,
-                            filter: data.getFilter(),
-                            displayName: data.displayName
-                        })
-                    }
-                }}>
-                <SelectTrigger className="w-[180px]">
-                    <SelectValue placeholder="Select a filter" />
-                </SelectTrigger>
-                <SelectContent>
-                    <SelectGroup>
-                        <SelectLabel>Filters</SelectLabel>
-                        {Object.entries(FilterPresets).map(([id, preset]) => (
-                            <SelectItem key={id} value={id}>
-                                {preset.displayName}
-                            </SelectItem>
-                        ))}
-                    </SelectGroup>
-                </SelectContent>
-            </Select>
-        </div>
+        <select
+            aria-label="Activity filter"
+            className={cn(
+                "border-input focus-visible:border-ring focus-visible:ring-ring/50",
+                "h-9 w-[180px] rounded-md border bg-transparent px-3 py-2 text-sm shadow-xs",
+                "outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50"
+            )}
+            value={filter?.id ?? "Default"}
+            onChange={event => {
+                const value = event.target.value as keyof typeof FilterPresets
+                const preset = FilterPresets[value]
+                if (!preset) return
+
+                setFilter({
+                    id: value,
+                    filter: preset.getFilter(),
+                    displayName: preset.displayName
+                })
+            }}>
+            {Object.entries(FilterPresets).map(([id, preset]) => (
+                <option key={id} value={id}>
+                    {preset.displayName}
+                </option>
+            ))}
+        </select>
     )
 }

--- a/src/components/providers/DestinyManifestManager.tsx
+++ b/src/components/providers/DestinyManifestManager.tsx
@@ -3,7 +3,6 @@
 import { Collection } from "@discordjs/collection"
 import { useMutation, useQuery } from "@tanstack/react-query"
 import { getDestinyManifest } from "bungie-net-core/endpoints/Destiny2"
-import Dexie from "dexie"
 import { createContext, useCallback, useContext, useEffect, useState, type ReactNode } from "react"
 import { useInterval } from "~/hooks/util/useInterval"
 import { useLocalStorage } from "~/hooks/util/useLocalStorage"
@@ -11,6 +10,8 @@ import { sentryOptionalQueryMeta } from "~/lib/sentry/react-query"
 import { type BungiePlatformError } from "~/models/BungieAPIError"
 import {
     DB_VERSION,
+    isDexieConnectionLostError,
+    recoverDexieDatabase,
     useDexie,
     type CustomDexieTable,
     type CustomDexieTableDefinition
@@ -57,13 +58,34 @@ const DestinyManifestManager = ({ children }: { children: ReactNode }) => {
         []
     )
 
-    const { mutateAsync: storeManifest, ...mutationState } = useMutation({
+    const { mutateAsync: storeManifest, ...mutationState } = useMutation<
+        string,
+        Error,
+        Parameters<typeof dexieDB.updateDefinitions>[1]
+    >({
         mutationFn: (args: Parameters<typeof dexieDB.updateDefinitions>[1]) =>
             dexieDB.updateDefinitions(seedCache, args),
         meta: sentryOptionalQueryMeta,
         onSuccess: setManifestVersion,
-        onError: async (err: Error | Error[]) => {
-            const errors = Array.isArray(err) ? err : [err]
+        onError: async (err: Error) => {
+            if (isDexieConnectionLostError(err)) {
+                try {
+                    await recoverDexieDatabase(dexieDB)
+                } catch (recoveryError) {
+                    console.error(
+                        "Failed to recover Dexie database after connection loss",
+                        recoveryError
+                    )
+                }
+                return
+            }
+
+            const errors =
+                err instanceof AggregateError
+                    ? err.errors.filter((e): e is Error => e instanceof Error)
+                    : err instanceof Error
+                      ? [err]
+                      : []
 
             if (
                 errors.some(
@@ -76,22 +98,18 @@ const DestinyManifestManager = ({ children }: { children: ReactNode }) => {
             setManifestVersion(null)
             console.warn(
                 `Failed to store the Destiny 2 manifest definitions with error(s): ${
-                    Array.isArray(err)
-                        ? "\n" + err.map((e, idx) => `${idx + 1}. ${e.message}`).join(",\n")
-                        : err.message
+                    errors.length
+                        ? "\n" + errors.map((e, idx) => `${idx + 1}. ${e.message}`).join(",\n")
+                        : String(err)
                 }.`
             )
 
-            if (
-                (Array.isArray(err) ? err : [err]).some(
-                    e => e instanceof Dexie.DexieError || e.message.includes("Dexie")
-                )
-            ) {
-                // Force a reset if there was a dexie related error
+            if (errors.some(e => e.name.startsWith("Dexie") || e.message.includes("Dexie"))) {
                 try {
                     await dexieDB.delete()
-                } catch (err) {
-                    console.error("Failed to reset the Dexie database", err)
+                    await dexieDB.open()
+                } catch (resetError) {
+                    console.error("Failed to reset the Dexie database", resetError)
                 }
             }
         }
@@ -151,7 +169,17 @@ const DestinyManifestManager = ({ children }: { children: ReactNode }) => {
     })
 
     useEffect(() => {
-        dexieDB.on("close", () => setManifestVersion(null))
+        const onClose = () => {
+            setManifestVersion(null)
+            void recoverDexieDatabase(dexieDB).catch(error => {
+                console.error("Failed to recover Dexie database after close", error)
+            })
+        }
+
+        dexieDB.on("close", onClose)
+        return () => {
+            dexieDB.on("close").unsubscribe(onClose)
+        }
     }, [dexieDB, setManifestVersion])
 
     return (

--- a/src/lib/server/saferFetch.ts
+++ b/src/lib/server/saferFetch.ts
@@ -3,8 +3,32 @@ import { withRetries } from "./retry"
 const retriableErrorCauseStrings = [
     "socket disconnected before secure TLS connection was established",
     "connect ETIMEDOUT",
-    "other side closed"
+    "other side closed",
+    "write EPIPE",
+    "read ECONNRESET",
+    "ECONNRESET",
+    "fetch failed",
+    "network error",
+    "Connection terminated unexpectedly"
 ]
+
+function collectErrorMessages(err: unknown): string[] {
+    const messages: string[] = []
+    let current: unknown = err
+
+    while (current instanceof Error) {
+        messages.push(current.message)
+        current = current.cause
+    }
+
+    return messages
+}
+
+function isRetriableFetchError(err: unknown): boolean {
+    return collectErrorMessages(err).some(message =>
+        retriableErrorCauseStrings.some(str => message.includes(str))
+    )
+}
 
 // WeakMap to hold buffered request bodies for Requests we've seen before.
 // Using a WeakMap lets buffers be garbage-collected when the original
@@ -62,19 +86,7 @@ export const saferFetch = withRetries(
     {
         maxAttempts: 5,
         backoff: attempt => attempt ** 2 * 5,
-        retryOn: err => {
-            if (err instanceof Error) {
-                const cause = err.cause
-                if (!cause) return false
-
-                return (
-                    cause instanceof Error &&
-                    retriableErrorCauseStrings.some(str => cause.message.includes(str))
-                )
-            }
-
-            return false
-        }
+        retryOn: isRetriableFetchError
     },
     fetchWithBodyClone
 )

--- a/src/util/dexie/dexie.ts
+++ b/src/util/dexie/dexie.ts
@@ -276,7 +276,48 @@ class CustomDexie extends Dexie implements Tables {
             return newManifestVersion
         }
 
-        throw errors.map(e => (e instanceof Error ? e : new Error(String(e.reason))))
+        const rejected = errors.map(result =>
+            result.reason instanceof Error ? result.reason : new Error(String(result.reason))
+        )
+
+        if (rejected.length === 1) {
+            throw rejected[0]
+        }
+
+        throw new AggregateError(rejected, "Destiny manifest update failed")
+    }
+}
+
+export function isDexieConnectionLostError(err: unknown): boolean {
+    const errors: unknown[] =
+        err instanceof AggregateError
+            ? Array.from(err.errors)
+            : Array.isArray(err)
+              ? err
+              : err
+                ? [err]
+                : []
+
+    return errors.some(error => {
+        if (!(error instanceof Error)) return false
+
+        return (
+            error.name === "DatabaseClosedError" ||
+            error.name === "InvalidStateError" ||
+            error.message.includes("DatabaseClosedError") ||
+            error.message.includes("Connection to Indexed Database server lost")
+        )
+    })
+}
+
+export async function recoverDexieDatabase(db: CustomDexie): Promise<void> {
+    try {
+        if (!db.isOpen()) {
+            await db.open()
+        }
+    } catch {
+        await db.delete()
+        await db.open()
     }
 }
 


### PR DESCRIPTION
## Summary
- **WEBSITE-21 / 23:** Replace profile `FilterSelect` Radix `Select` (portal) with native `<select>` — root cause of `removeChild` / `NotFoundError` on `/profile`.
- **WEBSITE-20 / 24:** Expand `saferFetch` retries for Turso transient failures (`write EPIPE`, `fetch failed`, `ECONNRESET`, etc.) on `profile.getUnique`.
- **WEBSITE-26 / 1Z:** Fix Dexie manifest update throwing a raw **array** of errors (unhandled rejection `[{},{},…]`); use `AggregateError` instead. Add `recoverDexieDatabase` on IDB `close` / `DatabaseClosedError`.
- **WEBSITE-1T:** Add `browserslist` targeting `ios >= 14` / `safari >= 14` so SWC downlevels client chunks for older Mobile Safari.

## Test plan
- [x] `bunx tsc --noEmit`
- [x] `bun run lint`
- [x] `bun run build`
- [ ] Post-merge: soak Sentry unresolved list; confirm WEBSITE-21/20/26 event rates drop


Made with [Cursor](https://cursor.com)