### PR TITLE
Fix remaining Sentry noise: storage, network retries, PGCR Dexie

### DIFF
--- a/src/app/leaderboards/LeaderboardSplashComponents.tsx
+++ b/src/app/leaderboards/LeaderboardSplashComponents.tsx
@@ -1,8 +1,8 @@
 "use client"
 
 import Link from "next/link"
+import { cloneElement, isValidElement } from "react"
 import styled, { css } from "styled-components"
-import { TooltipContainer, TooltipData } from "~/components/Tooltip"
 import { Panel } from "~/components/__deprecated__/Panel"
 import { Flex } from "~/components/__deprecated__/layout/Flex"
 import { H4 } from "~/components/__deprecated__/typography/H4"
@@ -49,19 +49,15 @@ const Subtitle = styled.div`
         font-size: 2.75rem;
     `}
 `
+
 export const TooltipWrapper = ({
-    id,
     title,
     children
 }: {
     title: string
     id: string
     children: JSX.Element
-}) => (
-    <TooltipContainer tooltipId={id} tooltipBody={<TooltipData $mb={0.5}>{title}</TooltipData>}>
-        {children}
-    </TooltipContainer>
-)
+}) => (isValidElement(children) ? cloneElement(children, { title } as { title: string }) : children)
 
 export const ExtLink = styled(Link).attrs({ target: "_blank" })`
     display: flex;

--- a/src/components/providers/QueryManager.tsx
+++ b/src/components/providers/QueryManager.tsx
@@ -8,6 +8,7 @@ import { useState } from "react"
 import superjson from "superjson"
 import { captureClientException } from "~/lib/sentry/capture"
 import {
+    isRetriableNetworkError,
     shouldSkipMutationCapture,
     shouldSkipReactQueryCapture,
     shouldSkipTrpcCapture
@@ -102,7 +103,8 @@ export function QueryManager(props: { children: React.ReactNode }) {
                         staleTime: 60000,
                         refetchOnWindowFocus: false,
                         refetchOnReconnect: true,
-                        retry: false,
+                        retry: (failureCount, error) =>
+                            failureCount < 3 && isRetriableNetworkError(error),
                         refetchIntervalInBackground: false,
                         suspense: false,
                         useErrorBoundary: false,

--- a/src/hooks/pgcr/ClientStateManager.tsx
+++ b/src/hooks/pgcr/ClientStateManager.tsx
@@ -92,13 +92,21 @@ export const ClientStateManager = ({
     }, [queryClient, data])
 
     const dexie = useDexie()
-    const weapons = useLiveQuery(() =>
-        dexie.items.bulkGet(
-            data.players.flatMap(p => p.characters.flatMap(c => c.weapons.map(w => w.weaponHash)))
-        )
+    const weapons = useLiveQuery(
+        () =>
+            dexie.items
+                .bulkGet(
+                    data.players.flatMap(p =>
+                        p.characters.flatMap(c => c.weapons.map(w => w.weaponHash))
+                    )
+                )
+                .catch((): (DestinyInventoryItemDefinition | undefined)[] => []),
+        [data.players]
     )
     const weaponsMap = new Collection(
-        weapons?.filter((w): w is DestinyInventoryItemDefinition => !!w).map(w => [w.hash, w])
+        (weapons ?? [])
+            .filter((weapon): weapon is DestinyInventoryItemDefinition => weapon !== undefined)
+            .map(weapon => [weapon.hash, weapon])
     )
 
     const [isReportModalOpen, setIsReportModalOpen] = useState(false)

--- a/src/hooks/util/useLocalStorage.ts
+++ b/src/hooks/util/useLocalStorage.ts
@@ -1,5 +1,21 @@
 import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from "react"
 
+function safeGetItem(key: string): string | null {
+    try {
+        return localStorage.getItem(key)
+    } catch {
+        return null
+    }
+}
+
+function safeSetItem(key: string, value: string): void {
+    try {
+        localStorage.setItem(key, value)
+    } catch {
+        // Safari private mode / disabled storage — keep in-memory state only.
+    }
+}
+
 export const useLocalStorage = <V extends string | boolean | number | object | null>(
     key: string,
     defaultValue: V | (() => V)
@@ -7,7 +23,7 @@ export const useLocalStorage = <V extends string | boolean | number | object | n
     const [_value, setValue] = useState<V>(defaultValue)
 
     useEffect(() => {
-        const fromStore = localStorage.getItem(key)
+        const fromStore = safeGetItem(key)
         const getDefault = () => (defaultValue instanceof Function ? defaultValue() : defaultValue)
         const parse = (value: string) => {
             try {
@@ -23,7 +39,7 @@ export const useLocalStorage = <V extends string | boolean | number | object | n
         (value: SetStateAction<V>) => {
             setValue(old => {
                 const toSave = value instanceof Function ? value(old) : value
-                localStorage.setItem(key, JSON.stringify(toSave))
+                safeSetItem(key, JSON.stringify(toSave))
                 return toSave
             })
         },
@@ -42,7 +58,7 @@ export const useLocalStorageObject = <V>(args: {
     const [store, setStore] = useState<Record<string, V>>({ [args.paramKey]: args.defaultValue })
 
     useEffect(() => {
-        const fromStore = localStorage.getItem(args.storageKey)
+        const fromStore = safeGetItem(args.storageKey)
         const parsed = fromStore ? (JSON.parse(fromStore) as Record<string, V>) : {}
         if (args.paramKey in parsed) {
             setValue(fromStore ? parsed[args.paramKey] : args.defaultValue)
@@ -51,12 +67,12 @@ export const useLocalStorageObject = <V>(args: {
 
     const save = (value: V | ((old: V) => V)) => {
         const toSave = typeof value === "function" ? (value as (old: V) => V)(_value) : value
-        const currStore = localStorage.getItem(args.storageKey)
+        const currStore = safeGetItem(args.storageKey)
         const newValue = {
             ...(currStore ? (JSON.parse(currStore) as Record<string, V>) : {}),
             [args.paramKey]: toSave
         }
-        localStorage.setItem(args.storageKey, JSON.stringify(newValue))
+        safeSetItem(args.storageKey, JSON.stringify(newValue))
         setValue(toSave)
         setStore(newValue)
     }

--- a/src/lib/sentry/policy.ts
+++ b/src/lib/sentry/policy.ts
@@ -115,7 +115,8 @@ function isTransientTrpcHtmlError(error: unknown): boolean {
     return message.includes("Unexpected token '<'") || message.includes("<!DOCTYPE")
 }
 
-function isAmbientNetworkError(error: unknown): boolean {
+/** Client fetch failures that often succeed on retry (offline blip, tab sleep, CDN hiccup). */
+export function isRetriableNetworkError(error: unknown): boolean {
     const message = getErrorMessage(error)
 
     if (
@@ -200,7 +201,7 @@ export function shouldSkipCapture(error: unknown): boolean {
 
 /** tRPC client — connectivity blips while offline or on bad networks. */
 export function shouldSkipTrpcCapture(error: unknown): boolean {
-    return shouldSkipCapture(error) || isAmbientNetworkError(error)
+    return shouldSkipCapture(error) || isRetriableNetworkError(error)
 }
 
 export function shouldSkipReactQueryCapture(
@@ -224,7 +225,7 @@ export function shouldSkipReactQueryCapture(
     }
 
     // Refetch failed but stale data is still shown — user-visible state is fine.
-    return isAmbientNetworkError(error) && query.state.data !== undefined
+    return isRetriableNetworkError(error) && query.state.data !== undefined
 }
 
 export function shouldSkipMutationCapture(mutation: { meta?: SentryQueryMeta }): boolean {


### PR DESCRIPTION
## Summary
- **WEBSITE-22:** Wrap `localStorage` in `useLocalStorage` with try/catch — fixes `SecurityError: The operation is insecure` (Safari private mode).
- **WEBSITE-1W / 1X / 1Y:** Enable react-query retries (up to 3) for transient `Failed to fetch` / `Load failed` before tRPC/react-query capture fires.
- **WEBSITE-25:** Catch Dexie `bulkGet` failures in PGCR `ClientStateManager` when IndexedDB connection is lost.
- Leaderboard speedrun link tooltips → native `title` (drops custom hover portal).

Companion to #371.

## Test plan
- [x] `bunx tsc --noEmit`
- [x] `bun run lint`
- [ ] Post-merge: unresolved count should drop to extension-only (WEBSITE-1V) after soak


Made with [Cursor](https://cursor.com)