### PR TITLE
Fix Sentry batch 18: Bungie transients, calendar vanity, IDB guards

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -54,8 +54,8 @@ const nextConfig = {
     rewrites: () => [
         {
             destination: "/user/:vanity",
-            // Exclude reserved slugs that have their own filesystem routes (e.g. /checkpoints).
-            source: "/:vanity((?!checkpoints$)[a-zA-Z0-9]+)"
+            // Exclude reserved slugs that have their own filesystem routes (e.g. /checkpoints, /calendar).
+            source: "/:vanity((?!checkpoints$|calendar$)[a-zA-Z0-9]+)"
         }
     ]
 }

--- a/src/app/calendar/page.tsx
+++ b/src/app/calendar/page.tsx
@@ -1,0 +1,6 @@
+import NotFound from "~/app/not-found"
+
+/** Reserved path — without this page, /calendar is rewritten to /user/calendar and 404s via vanity lookup. */
+export default function CalendarPage() {
+    return <NotFound />
+}

--- a/src/components/profile/transitory/CurrentActivity.tsx
+++ b/src/components/profile/transitory/CurrentActivity.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useQueries } from "@tanstack/react-query"
+import { useQuery, useQueryClient } from "@tanstack/react-query"
 import type {
     BungieMembershipType,
     DestinyCharacterActivitiesComponent,
@@ -17,6 +17,7 @@ import { H4 } from "~/components/__deprecated__/typography/H4"
 import { useActivityDefinition, useActivityModeDefinition, useItemDefinition } from "~/hooks/dexie"
 import { useTimer } from "~/hooks/util/useTimer"
 import type { ProfileProps } from "~/lib/profile/types"
+import { sentryOptionalQueryMeta } from "~/lib/sentry/react-query"
 import { useProfileLiveData, useProfileTransitory } from "~/services/bungie/hooks"
 import { getRaidHubApi } from "~/services/raidhub/common"
 import { type RaidHubPlayerInfo } from "~/services/raidhub/types"
@@ -130,28 +131,36 @@ const CurrentActivityCard = (props: {
         () => props.partyMembers.map(pm => pm.membershipId),
         [props.partyMembers]
     )
+    const sortedPartyMemberIds = useMemo(
+        () => [...partyMemberIds].sort((a, b) => a.localeCompare(b)),
+        [partyMemberIds]
+    )
 
-    const resolvedPlayers = useQueries({
-        queries: partyMemberIds.map(membershipId => ({
-            queryKey: ["raidhub", "player", "basic", membershipId] as const,
-            queryFn: () =>
-                getRaidHubApi("/player/{membershipId}/basic", { membershipId }, null).then(
-                    res => res.response
-                ),
-            staleTime: 1000 * 60 * 60
-        }))
+    const queryClient = useQueryClient()
+    const { data: resolvedById = new Map<string, RaidHubPlayerInfo>() } = useQuery({
+        queryKey: ["raidhub", "player", "basic", "fireteam", sortedPartyMemberIds] as const,
+        queryFn: async () => {
+            const players = await Promise.all(
+                sortedPartyMemberIds.map(membershipId =>
+                    getRaidHubApi("/player/{membershipId}/basic", { membershipId }, null).then(
+                        res => res.response
+                    )
+                )
+            )
+
+            players.forEach(player => {
+                queryClient.setQueryData(
+                    ["raidhub", "player", "basic", player.membershipId],
+                    player
+                )
+            })
+
+            return new Map(players.map(player => [player.membershipId, player]))
+        },
+        enabled: sortedPartyMemberIds.length > 0,
+        staleTime: 1000 * 60 * 60,
+        meta: sentryOptionalQueryMeta
     })
-
-    const resolvedById = useMemo(() => {
-        const map = new Map<string, RaidHubPlayerInfo>()
-        partyMemberIds.forEach((membershipId, index) => {
-            const player = resolvedPlayers[index]?.data
-            if (player) {
-                map.set(membershipId, player)
-            }
-        })
-        return map
-    }, [partyMemberIds, resolvedPlayers])
 
     return (
         <Latest $playerCount={props.partyMembers.length}>

--- a/src/lib/sentry/policy.ts
+++ b/src/lib/sentry/policy.ts
@@ -1,5 +1,5 @@
 import type { ErrorEvent } from "@sentry/nextjs"
-import { BungiePlatformError } from "~/models/BungieAPIError"
+import { BungieHTMLError, BungiePlatformError } from "~/models/BungieAPIError"
 import BaseBungieClient from "~/services/bungie/BungieClient"
 import { RaidHubError } from "~/services/raidhub/RaidHubError"
 import type { RaidHubErrorCode } from "~/services/raidhub/types"
@@ -73,10 +73,15 @@ function isBenignClientStorageError(error: unknown): boolean {
 
     return (
         name === "DatabaseClosedError" ||
+        name === "SecurityError" ||
+        name === "InvalidStateError" ||
         message.includes("OpenFailedError") ||
         message.includes("Database deleted by request of the user") ||
         message.includes("Connection to Indexed Database server lost") ||
-        message.includes("DatabaseClosedError")
+        message.includes("DatabaseClosedError") ||
+        message.includes("invalid security context") ||
+        message.includes("IDBTransaction") ||
+        message.includes("The operation is insecure")
     )
 }
 
@@ -100,7 +105,28 @@ function isBenignDomMutationError(error: unknown): boolean {
 }
 
 function isExtensionInjectedError(error: unknown): boolean {
-    return /_0x[0-9a-f]+/i.test(getErrorMessage(error))
+    const message = getErrorMessage(error)
+    return (
+        /_0x[0-9a-f]+/i.test(message) ||
+        message.includes("Can't find variable: CONFIG") ||
+        message.includes("Can't find variable: currentInset") ||
+        message === "CONFIG is not defined" ||
+        message === "currentInset is not defined"
+    )
+}
+
+function isBungieHtmlAuthError(error: unknown): boolean {
+    return error instanceof BungieHTMLError && error.status === 401
+}
+
+function isBenignMediaPlaybackError(error: unknown): boolean {
+    const message = getErrorMessage(error)
+    const name = error instanceof Error ? error.name : ""
+
+    return (
+        name === "NotAllowedError" &&
+        message.includes("play method is not allowed by the user agent")
+    )
 }
 
 function isExpectedBungiePlatformError(error: unknown): boolean {
@@ -174,6 +200,14 @@ export function shouldSkipCapture(error: unknown): boolean {
     }
 
     if (isExtensionInjectedError(error)) {
+        return true
+    }
+
+    if (isBungieHtmlAuthError(error)) {
+        return true
+    }
+
+    if (isBenignMediaPlaybackError(error)) {
         return true
     }
 
@@ -251,8 +285,14 @@ export function shouldDropClientEvent(event: ErrorEvent): boolean {
         text.includes("Database deleted by request of the user") ||
         text.includes("OpenFailedError") ||
         text.includes("Connection to Indexed Database server lost") ||
-        text.includes("DatabaseClosedError")
+        text.includes("DatabaseClosedError") ||
+        text.includes("invalid security context") ||
+        text.includes("The operation is insecure")
     ) {
+        return true
+    }
+
+    if (text.includes("IDBTransaction") || text.includes("InvalidStateError")) {
         return true
     }
 
@@ -280,7 +320,14 @@ export function shouldDropClientEvent(event: ErrorEvent): boolean {
     }
 
     // Extension / injected script noise (obfuscated identifiers, no app frames).
-    if (!hasAppStackFrame && /_0x[0-9a-f]+/i.test(text)) {
+    if (
+        !hasAppStackFrame &&
+        (/_0x[0-9a-f]+/i.test(text) ||
+            text.includes("Can't find variable: CONFIG") ||
+            text.includes("Can't find variable: currentInset") ||
+            text.includes("CONFIG is not defined") ||
+            text.includes("currentInset is not defined"))
+    ) {
         return true
     }
 

--- a/src/services/bungie/BungieClient.ts
+++ b/src/services/bungie/BungieClient.ts
@@ -82,6 +82,7 @@ export default abstract class BaseBungieClient implements BungieClientProtocol {
 
     static readonly RetryableErrorCodes = new Set<PlatformErrorCodes>([
         1672, // DestinyThrottledByGameServer,
+        1618, // DestinyUnexpectedError — Bungie 500 blips, often succeeds on retry
         1688 // DestinyDirectBabelClientTimeout
     ])
 
@@ -89,6 +90,8 @@ export default abstract class BaseBungieClient implements BungieClientProtocol {
         5, // SystemDisabled
         18, // InvalidParameters — bad membership/type combos on optional lookups (e.g. clans)
         686, // ClanNotFound
-        1653 // PGCRNotFound
+        1618, // DestinyUnexpectedError — Bungie-side 500, surfaced in UI as load failure
+        1653, // PGCRNotFound
+        1688 // DestinyDirectBabelClientTimeout
     ])
 }

--- a/src/util/dexie/dexie.ts
+++ b/src/util/dexie/dexie.ts
@@ -315,9 +315,17 @@ export async function recoverDexieDatabase(db: CustomDexie): Promise<void> {
         if (!db.isOpen()) {
             await db.open()
         }
-    } catch {
-        await db.delete()
-        await db.open()
+    } catch (error) {
+        if (error instanceof DOMException && error.name === "SecurityError") {
+            return
+        }
+
+        try {
+            await db.delete()
+            await db.open()
+        } catch {
+            // IndexedDB blocked (private mode, cross-origin iframe, etc.) — manifest stays in-memory.
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- **WEBSITE-2D / 2E / 1F:** Bungie `1618` (unexpected 500) and `1688` (timeout) → retry once in client + treat as expected/handled (no Sentry capture).
- **WEBSITE-1A / 2B:** `BungieHTMLError` 401 (expired session HTML page) → skip capture; auth recovery path already handles.
- **WEBSITE-5 / 3 / 4:** `/calendar` hit vanity rewrite → `/user/calendar` 404 RSC noise. Added reserved `calendar` page + rewrite exclusion (same pattern as `checkpoints`).
- **WEBSITE-27–29 / 2A / G:** IndexedDB `SecurityError` / `InvalidStateError` → benign storage policy + safe Dexie recovery when IDB blocked.
- **WEBSITE-2M / 2K / 1V:** Extension globals (`CONFIG`, `currentInset`, `_0x`) → drop when no app stack frames.
- **WEBSITE-2Q:** Autoplay `NotAllowedError` on PGCR → benign media policy.
- **WEBSITE-1E:** Fireteam `/player/basic` N+1 → single batched react-query with per-member cache seeding.

## Test plan
- [x] `bunx tsc --noEmit`
- [x] `bun run lint`
- [ ] Post-merge: unresolved count should drop sharply; soak Bungie blips during maintenance windows


Made with [Cursor](https://cursor.com)