### PR TITLE
Sentry prevention infrastructure

### DIFF
--- a/.github/workflows/static-pr-checks.yaml
+++ b/.github/workflows/static-pr-checks.yaml
@@ -71,3 +71,17 @@ jobs:
 
             - name: "migrate:drift"
               run: bun migrate:drift
+
+    vanity-slugs:
+        name: Vanity slug sync
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Setup Bun
+              uses: oven-sh/setup-bun@v1
+              with:
+                  bun-version: latest
+
+            - name: Check vanity rewrite exclusions
+              run: bun run check:vanity-slugs

--- a/example.env
+++ b/example.env
@@ -35,6 +35,9 @@ AWS_S3_REGION="us-east-1"
 # NEXT_PUBLIC_SENTRY_DSN=""
 # SENTRY_ENVIRONMENT="development"
 # SENTRY_RELEASE=""
+# SENTRY_ORG="raidhub"
+# SENTRY_PROJECT="website"
+# SENTRY_AUTH_TOKEN="" # Required on Vercel production builds for client source map upload
 
 ### DO NOT MODIFY BELOW ###
 APP_ENV="local"

--- a/next.config.js
+++ b/next.config.js
@@ -1,4 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
+const reservedVanitySlugs = require("./routing/reserved-vanity-slugs.json")
+// eslint-disable-next-line @typescript-eslint/no-var-requires
 const { withSentryConfig } = require("@sentry/nextjs")
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const withBundleAnalyzer = require("@next/bundle-analyzer")({
@@ -51,16 +53,23 @@ const nextConfig = {
             }
         ]
     },
-    rewrites: () => [
-        {
-            destination: "/user/:vanity",
-            // Exclude reserved slugs that have their own filesystem routes (e.g. /checkpoints, /calendar).
-            source: "/:vanity((?!checkpoints$|calendar$)[a-zA-Z0-9]+)"
-        }
-    ]
+    rewrites: () => {
+        const vanityExclusion = reservedVanitySlugs.map(slug => `${slug}$`).join("|")
+
+        return [
+            {
+                destination: "/user/:vanity",
+                // Keep in sync with routing/reserved-vanity-slugs.json (see scripts/check-vanity-slugs.mjs).
+                source: `/:vanity((?!${vanityExclusion})[a-zA-Z0-9]+)`
+            }
+        ]
+    }
 }
 
 module.exports = withSentryConfig(withBundleAnalyzer(nextConfig), {
     silent: !process.env.CI,
-    widenClientFileUpload: true
+    widenClientFileUpload: true,
+    org: process.env.SENTRY_ORG,
+    project: process.env.SENTRY_PROJECT,
+    authToken: process.env.SENTRY_AUTH_TOKEN
 })

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
         "lint": "next lint",
         "format": "prettier --write \"src/**/*.{ts,tsx,json}\" && prisma format",
         "format:check": "prettier --check \"src/**/*.{ts,tsx,json}\"",
+        "check:vanity-slugs": "bun scripts/check-vanity-slugs.mjs",
         "build": "bun prisma generate && next build",
         "deploy": "./vercel/dev-deploy.sh"
     },
@@ -164,8 +165,61 @@
             "@next/next/no-page-custom-font": "off",
             "@typescript-eslint/unbound-method": "off",
             "@typescript-eslint/no-unsafe-enum-comparison": "off",
-            "@typescript-eslint/no-misused-promises": "off"
-        }
+            "@typescript-eslint/no-misused-promises": "off",
+            "no-restricted-globals": [
+                "error",
+                {
+                    "name": "localStorage",
+                    "message": "Use ~/lib/storage/safeStorage instead of localStorage directly."
+                }
+            ]
+        },
+        "overrides": [
+            {
+                "files": ["src/lib/storage/**/*.ts", "src/hooks/util/useLocalStorage.ts"],
+                "rules": {
+                    "no-restricted-globals": "off"
+                }
+            },
+            {
+                "files": [
+                    "src/components/profile/**/*",
+                    "src/components/pgcr/**/*",
+                    "src/hooks/pgcr/**/*",
+                    "src/app/pgcr/**/*",
+                    "src/app/(profile)/**/*"
+                ],
+                "rules": {
+                    "no-restricted-imports": [
+                        "error",
+                        {
+                            "paths": [
+                                {
+                                    "name": "@radix-ui/react-select",
+                                    "message": "Use native <select> on profile/PGCR routes."
+                                },
+                                {
+                                    "name": "@radix-ui/react-tooltip",
+                                    "message": "Use the title attribute on profile/PGCR routes."
+                                },
+                                {
+                                    "name": "~/shad/select",
+                                    "message": "Use native <select> on profile/PGCR routes."
+                                },
+                                {
+                                    "name": "~/shad/tooltip",
+                                    "message": "Use the title attribute on profile/PGCR routes."
+                                },
+                                {
+                                    "name": "~/components/Tooltip",
+                                    "message": "Use the title attribute on profile/PGCR routes."
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        ]
     },
     "browserslist": [
         "chrome >= 87",

--- a/routing/reserved-vanity-slugs.json
+++ b/routing/reserved-vanity-slugs.json
@@ -10,6 +10,5 @@
     "faq",
     "leaderboards",
     "multi",
-    "pgcr",
-    "test"
+    "pgcr"
 ]

--- a/routing/reserved-vanity-slugs.json
+++ b/routing/reserved-vanity-slugs.json
@@ -1,0 +1,15 @@
+[
+    "account",
+    "admin",
+    "analytics",
+    "auth",
+    "calendar",
+    "checkpoints",
+    "clan",
+    "clans",
+    "faq",
+    "leaderboards",
+    "multi",
+    "pgcr",
+    "test"
+]

--- a/scripts/check-vanity-slugs.mjs
+++ b/scripts/check-vanity-slugs.mjs
@@ -4,6 +4,7 @@
  * Run: bun scripts/check-vanity-slugs.mjs
  */
 import { existsSync, readdirSync, readFileSync } from "node:fs"
+import { execSync } from "node:child_process"
 import { dirname, join } from "node:path"
 import { fileURLToPath } from "node:url"
 
@@ -11,6 +12,15 @@ const root = join(dirname(fileURLToPath(import.meta.url)), "..")
 const appDir = join(root, "src/app")
 const configPath = join(root, "next.config.js")
 const slugsPath = join(root, "routing/reserved-vanity-slugs.json")
+
+const isGitIgnored = relativePath => {
+    try {
+        execSync(`git check-ignore -q ${relativePath}`, { cwd: root, stdio: "ignore" })
+        return true
+    } catch {
+        return false
+    }
+}
 
 const reserved = JSON.parse(readFileSync(slugsPath, "utf8"))
 if (!Array.isArray(reserved) || reserved.some(slug => typeof slug !== "string")) {
@@ -20,12 +30,15 @@ if (!Array.isArray(reserved) || reserved.some(slug => typeof slug !== "string"))
 
 const ignoredAppDirs = new Set(["api", "header"])
 
+const isTrackedAppRoute = name => !isGitIgnored(`src/app/${name}`)
+
 const topLevelAppSlugs = readdirSync(appDir, { withFileTypes: true })
     .filter(
         entry =>
             entry.isDirectory() &&
             !entry.name.startsWith("(") &&
             !ignoredAppDirs.has(entry.name) &&
+            isTrackedAppRoute(entry.name) &&
             existsSync(join(appDir, entry.name, "page.tsx"))
     )
     .map(entry => entry.name)
@@ -34,7 +47,10 @@ const topLevelAppSlugs = readdirSync(appDir, { withFileTypes: true })
 const urlPrefixes = readdirSync(appDir, { withFileTypes: true })
     .filter(
         entry =>
-            entry.isDirectory() && !entry.name.startsWith("(") && !ignoredAppDirs.has(entry.name)
+            entry.isDirectory() &&
+            !entry.name.startsWith("(") &&
+            !ignoredAppDirs.has(entry.name) &&
+            isTrackedAppRoute(entry.name)
     )
     .map(entry => entry.name)
     .sort()

--- a/scripts/check-vanity-slugs.mjs
+++ b/scripts/check-vanity-slugs.mjs
@@ -1,0 +1,94 @@
+#!/usr/bin/env bun
+/**
+ * Ensures vanity rewrite exclusions stay in sync with top-level app routes.
+ * Run: bun scripts/check-vanity-slugs.mjs
+ */
+import { existsSync, readdirSync, readFileSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const root = join(dirname(fileURLToPath(import.meta.url)), "..")
+const appDir = join(root, "src/app")
+const configPath = join(root, "next.config.js")
+const slugsPath = join(root, "routing/reserved-vanity-slugs.json")
+
+const reserved = JSON.parse(readFileSync(slugsPath, "utf8"))
+if (!Array.isArray(reserved) || reserved.some(slug => typeof slug !== "string")) {
+    console.error("reserved-vanity-slugs.json must be a string array")
+    process.exit(1)
+}
+
+const ignoredAppDirs = new Set(["api", "header"])
+
+const topLevelAppSlugs = readdirSync(appDir, { withFileTypes: true })
+    .filter(
+        entry =>
+            entry.isDirectory() &&
+            !entry.name.startsWith("(") &&
+            !ignoredAppDirs.has(entry.name) &&
+            existsSync(join(appDir, entry.name, "page.tsx"))
+    )
+    .map(entry => entry.name)
+    .sort()
+
+const urlPrefixes = readdirSync(appDir, { withFileTypes: true })
+    .filter(
+        entry =>
+            entry.isDirectory() && !entry.name.startsWith("(") && !ignoredAppDirs.has(entry.name)
+    )
+    .map(entry => entry.name)
+    .sort()
+
+const reservedSet = new Set(reserved)
+const missingFromReserved = urlPrefixes.filter(slug => !reservedSet.has(slug))
+const staleReserved = reserved.filter(slug => !urlPrefixes.includes(slug))
+
+const configSource = readFileSync(configPath, "utf8")
+const reservedSorted = [...reserved].sort()
+
+let failed = false
+
+if (missingFromReserved.length) {
+    failed = true
+    console.error(
+        "Top-level app URL prefixes missing from routing/reserved-vanity-slugs.json:",
+        missingFromReserved.join(", ")
+    )
+}
+
+if (staleReserved.length) {
+    failed = true
+    console.error(
+        "Stale entries in routing/reserved-vanity-slugs.json (no matching app folder):",
+        staleReserved.join(", ")
+    )
+}
+
+for (const slug of reservedSorted) {
+    if (!configSource.includes("routing/reserved-vanity-slugs.json")) {
+        failed = true
+        console.error("next.config.js must require routing/reserved-vanity-slugs.json")
+        break
+    }
+}
+
+if (!configSource.includes("vanityExclusion")) {
+    failed = true
+    console.error("next.config.js must build vanityExclusion from reservedVanitySlugs")
+}
+
+if (topLevelAppSlugs.some(slug => !reservedSet.has(slug))) {
+    failed = true
+    console.error(
+        "Top-level pages missing from reserved list:",
+        topLevelAppSlugs.filter(slug => !reservedSet.has(slug)).join(", ")
+    )
+}
+
+if (failed) {
+    process.exit(1)
+}
+
+console.log(
+    `Vanity slug check OK (${reserved.length} reserved, ${topLevelAppSlugs.length} top-level pages)`
+)

--- a/src/components/profile/raids/FilterContext.tsx
+++ b/src/components/profile/raids/FilterContext.tsx
@@ -12,6 +12,7 @@ import {
     decodeFilters,
     type ActivityFilter
 } from "~/lib/profile/filters/activityFilters"
+import { safeGetItem, safeSetItem } from "~/lib/storage/safeStorage"
 
 const FilterContext = createContext<
     | {
@@ -48,7 +49,7 @@ type EncodedFilterData = {
  * @returns The saved activity filter.
  */
 const saveFilter = (_: FilterData | null, data: FilterData | null) => {
-    localStorage.setItem(
+    safeSetItem(
         KEY_ACTIVITY_FILTER,
         JSON.stringify(
             data
@@ -77,7 +78,7 @@ export const FilterContextProvider = ({ children }: { children: ReactNode }) => 
     const [isMounted, setIsMounted] = useState(false)
 
     useEffect(() => {
-        const allFilters = localStorage.getItem(KEY_ACTIVITY_FILTER)
+        const allFilters = safeGetItem(KEY_ACTIVITY_FILTER)
         if (allFilters !== null) {
             try {
                 const fromStore = JSON.parse(allFilters) as EncodedFilterData

--- a/src/components/profile/transitory/CurrentActivity.tsx
+++ b/src/components/profile/transitory/CurrentActivity.tsx
@@ -19,7 +19,10 @@ import { useTimer } from "~/hooks/util/useTimer"
 import type { ProfileProps } from "~/lib/profile/types"
 import { sentryOptionalQueryMeta } from "~/lib/sentry/react-query"
 import { useProfileLiveData, useProfileTransitory } from "~/services/bungie/hooks"
-import { getRaidHubApi } from "~/services/raidhub/common"
+import {
+    fetchRaidHubPlayersBasic,
+    playersBasicByMembershipId
+} from "~/services/raidhub/fetchPlayersBasic"
 import { type RaidHubPlayerInfo } from "~/services/raidhub/types"
 import { Card } from "~/shad/card"
 import { bungieEmblemUrl, bungiePgcrImageUrl, bungieProfileIconUrl } from "~/util/destiny"
@@ -140,13 +143,7 @@ const CurrentActivityCard = (props: {
     const { data: resolvedById = new Map<string, RaidHubPlayerInfo>() } = useQuery({
         queryKey: ["raidhub", "player", "basic", "fireteam", sortedPartyMemberIds] as const,
         queryFn: async () => {
-            const players = await Promise.all(
-                sortedPartyMemberIds.map(membershipId =>
-                    getRaidHubApi("/player/{membershipId}/basic", { membershipId }, null).then(
-                        res => res.response
-                    )
-                )
-            )
+            const players = await fetchRaidHubPlayersBasic(sortedPartyMemberIds)
 
             players.forEach(player => {
                 queryClient.setQueryData(
@@ -155,7 +152,7 @@ const CurrentActivityCard = (props: {
                 )
             })
 
-            return new Map(players.map(player => [player.membershipId, player]))
+            return playersBasicByMembershipId(players)
         },
         enabled: sortedPartyMemberIds.length > 0,
         staleTime: 1000 * 60 * 60,

--- a/src/hooks/util/useLocalStorage.ts
+++ b/src/hooks/util/useLocalStorage.ts
@@ -1,20 +1,7 @@
 import { useCallback, useEffect, useState, type Dispatch, type SetStateAction } from "react"
+import { safeGetItem, safeSetItem } from "~/lib/storage/safeStorage"
 
-function safeGetItem(key: string): string | null {
-    try {
-        return localStorage.getItem(key)
-    } catch {
-        return null
-    }
-}
-
-function safeSetItem(key: string, value: string): void {
-    try {
-        localStorage.setItem(key, value)
-    } catch {
-        // Safari private mode / disabled storage — keep in-memory state only.
-    }
-}
+export { safeGetItem, safeRemoveItem, safeSetItem } from "~/lib/storage/safeStorage"
 
 export const useLocalStorage = <V extends string | boolean | number | object | null>(
     key: string,

--- a/src/lib/storage/safeStorage.ts
+++ b/src/lib/storage/safeStorage.ts
@@ -1,0 +1,28 @@
+/**
+ * Browser storage access that survives Safari private mode and disabled storage.
+ * Import this module instead of using `localStorage` directly.
+ */
+
+export function safeGetItem(key: string): string | null {
+    try {
+        return localStorage.getItem(key)
+    } catch {
+        return null
+    }
+}
+
+export function safeSetItem(key: string, value: string): void {
+    try {
+        localStorage.setItem(key, value)
+    } catch {
+        // Private browsing / disabled storage — caller keeps in-memory state only.
+    }
+}
+
+export function safeRemoveItem(key: string): void {
+    try {
+        localStorage.removeItem(key)
+    } catch {
+        // noop
+    }
+}

--- a/src/services/raidhub/fetchPlayersBasic.ts
+++ b/src/services/raidhub/fetchPlayersBasic.ts
@@ -1,0 +1,27 @@
+import { postRaidHubApi } from "~/services/raidhub/common"
+import { type RaidHubPlayerInfo } from "~/services/raidhub/types"
+
+/** Resolve up to 12 players via `POST /player/basic/batch`. */
+export async function fetchRaidHubPlayersBasic(
+    membershipIds: readonly string[]
+): Promise<RaidHubPlayerInfo[]> {
+    if (!membershipIds.length) {
+        return []
+    }
+
+    const uniqueIds = [...new Set(membershipIds)]
+    const response = await postRaidHubApi(
+        "/player/basic/batch",
+        "post",
+        { membershipIds: uniqueIds.slice(0, 12) },
+        null
+    )
+
+    return [...response.response.players]
+}
+
+export function playersBasicByMembershipId(
+    players: readonly RaidHubPlayerInfo[]
+): Map<string, RaidHubPlayerInfo> {
+    return new Map(players.map(player => [player.membershipId, player]))
+}

--- a/src/services/raidhub/openapi.d.ts
+++ b/src/services/raidhub/openapi.d.ts
@@ -199,6 +199,37 @@ export interface paths {
       };
     };
   };
+  "/player/basic/batch": {
+    /**
+     * /player/basic/batch
+     * @description Batch variant of `/player/{membershipId}/basic`. Resolves up to 12 players in one round-trip.
+     */
+    post: {
+      requestBody: {
+        content: {
+          "application/json": {
+            membershipIds: string[];
+          };
+        };
+      };
+      responses: {
+        /** @description Success */
+        200: {
+          content: {
+            readonly "application/json": {
+              /** Format: date-time */
+              readonly minted: string;
+              /** @enum {boolean} */
+              readonly success: true;
+              readonly response: {
+                readonly players: readonly components["schemas"]["PlayerInfo"][];
+              };
+            };
+          };
+        };
+      };
+    };
+  };
   "/player/{membershipId}/history": {
     /**
      * /player/{membershipId}/history


### PR DESCRIPTION
## Summary
- **Vanity routing:** `routing/reserved-vanity-slugs.json` is source of truth for rewrite exclusions; `scripts/check-vanity-slugs.mjs` + CI job keep it synced with `src/app/` URL prefixes.
- **Storage:** `src/lib/storage/safeStorage.ts` + ESLint `no-restricted-globals` on `localStorage`; migrated `FilterContext` off raw access.
- **N+1:** Fireteam display uses `POST /player/basic/batch` via `fetchRaidHubPlayersBasic` (one HTTP call).
- **UI guardrails:** ESLint `no-restricted-imports` blocks Radix select/tooltip on profile/PGCR paths.
- **Source maps:** `withSentryConfig` now accepts `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_AUTH_TOKEN` (set on Vercel prod build).

## Merge order
**API first** — companion PR: Raid-Hub/API `fix-player-basic-batch`

## Test plan
- [x] `bun run check:vanity-slugs`
- [x] `bun run lint`
- [x] `bunx tsc --noEmit`
- [x] `bun run build`
- [ ] After API deploy: verify fireteam card on profile with in-game activity


Made with [Cursor](https://cursor.com)