### PR TITLE
Fix three overnight Sentry issues

### DIFF
--- a/src/lib/sentry/policy.ts
+++ b/src/lib/sentry/policy.ts
@@ -191,6 +191,17 @@ function isTransientTrpcHtmlError(error: unknown): boolean {
     return message.includes("Unexpected token '<'") || message.includes("<!DOCTYPE")
 }
 
+/** Turso/libSQL blips — retried via saferFetch; still skip if all attempts fail. */
+function isTransientTursoPrismaError(error: unknown): boolean {
+    const message = getErrorMessage(error)
+    return (
+        message.includes("SERVER_ERROR") &&
+        (message.includes("HTTP status 502") ||
+            message.includes("HTTP status 503") ||
+            message.includes("HTTP status 504"))
+    )
+}
+
 /** Client fetch failures that often succeed on retry (offline blip, tab sleep, CDN hiccup). */
 export function isRetriableNetworkError(error: unknown): boolean {
     const message = getErrorMessage(error)
@@ -278,6 +289,10 @@ export function shouldSkipCapture(error: unknown): boolean {
     }
 
     if (isTransientTrpcHtmlError(error)) {
+        return true
+    }
+
+    if (isTransientTursoPrismaError(error)) {
         return true
     }
 
@@ -425,6 +440,15 @@ export function shouldDropClientEvent(event: ErrorEvent): boolean {
     }
 
     if (!hasAppStackFrame && /^Error: \S{1,3}$/.test(text.split("\n")[0] ?? "")) {
+        return true
+    }
+
+    // Minified-chunk parse failures on old browsers / bots (no app frames).
+    if (
+        !hasAppStackFrame &&
+        text.includes("SyntaxError") &&
+        text.includes("Unexpected token '{'")
+    ) {
         return true
     }
 

--- a/src/lib/sentry/shared-options.ts
+++ b/src/lib/sentry/shared-options.ts
@@ -3,6 +3,15 @@ import type { ErrorEvent, EventHint } from "@sentry/nextjs"
 /** Next.js App Router control-flow signals — not application bugs. */
 const NEXTJS_CONTROL_FLOW_ERRORS = ["NEXT_NOT_FOUND", "NEXT_REDIRECT"] as const
 
+type TransactionLike = {
+    transaction?: string
+}
+
+/** Standalone Prisma spans sampled as transactions — Turso latency noise, not app bugs. */
+export function shouldDropSentryTransaction(event: TransactionLike): boolean {
+    return event.transaction === "prisma:client:operation"
+}
+
 export function shouldDropSentryEvent(event: ErrorEvent, _hint?: EventHint): boolean {
     const values = event.exception?.values
     if (!values?.length) {
@@ -19,5 +28,8 @@ export const sentrySharedOptions = {
     beforeSend(event: ErrorEvent, hint: EventHint) {
         return shouldDropSentryEvent(event, hint) ? null : event
     },
-    ignoreErrors: [...NEXTJS_CONTROL_FLOW_ERRORS]
+    beforeSendTransaction(event: TransactionLike): TransactionLike | null {
+        return shouldDropSentryTransaction(event) ? null : event
+    },
+    ignoreErrors: [...NEXTJS_CONTROL_FLOW_ERRORS, "Unexpected token '{'"]
 }

--- a/src/lib/sentry/shared-options.ts
+++ b/src/lib/sentry/shared-options.ts
@@ -1,15 +1,17 @@
+import type { TransactionEvent } from "@sentry/core"
 import type { ErrorEvent, EventHint } from "@sentry/nextjs"
 
 /** Next.js App Router control-flow signals — not application bugs. */
 const NEXTJS_CONTROL_FLOW_ERRORS = ["NEXT_NOT_FOUND", "NEXT_REDIRECT"] as const
 
-type TransactionLike = {
-    transaction?: string
-}
-
 /** Standalone Prisma spans sampled as transactions — Turso latency noise, not app bugs. */
-export function shouldDropSentryTransaction(event: TransactionLike): boolean {
-    return event.transaction === "prisma:client:operation"
+export function shouldDropSentryTransaction(event: TransactionEvent): boolean {
+    const transaction =
+        typeof event === "object" && event !== null && "transaction" in event
+            ? (event as { transaction?: unknown }).transaction
+            : undefined
+
+    return transaction === "prisma:client:operation"
 }
 
 export function shouldDropSentryEvent(event: ErrorEvent, _hint?: EventHint): boolean {
@@ -28,8 +30,14 @@ export const sentrySharedOptions = {
     beforeSend(event: ErrorEvent, hint: EventHint) {
         return shouldDropSentryEvent(event, hint) ? null : event
     },
-    beforeSendTransaction(event: TransactionLike): TransactionLike | null {
-        return shouldDropSentryTransaction(event) ? null : event
+    beforeSendTransaction(event: TransactionEvent) {
+        if (shouldDropSentryTransaction(event)) {
+            return null
+        }
+
+        // TransactionEvent from @sentry/nextjs is `any` in ESLint; tsc expects the full event back.
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-return -- Sentry SDK transaction callback
+        return event
     },
     ignoreErrors: [...NEXTJS_CONTROL_FLOW_ERRORS, "Unexpected token '{'"]
 }

--- a/src/lib/server/saferFetch.ts
+++ b/src/lib/server/saferFetch.ts
@@ -9,8 +9,13 @@ const retriableErrorCauseStrings = [
     "ECONNRESET",
     "fetch failed",
     "network error",
-    "Connection terminated unexpectedly"
+    "Connection terminated unexpectedly",
+    "HTTP status 502",
+    "HTTP status 503",
+    "HTTP status 504"
 ]
+
+const retriableHttpStatuses = new Set([502, 503, 504])
 
 function collectErrorMessages(err: unknown): string[] {
     const messages: string[] = []
@@ -82,11 +87,24 @@ const fetchWithBodyClone: typeof fetch = async (request, options) => {
     return fetch(request, options)
 }
 
+async function fetchWithRetriableStatuses(
+    request: RequestInfo | URL,
+    options?: RequestInit
+): Promise<Response> {
+    const response = await fetchWithBodyClone(request, options)
+
+    if (retriableHttpStatuses.has(response.status)) {
+        throw new Error(`Server returned HTTP status ${response.status}`)
+    }
+
+    return response
+}
+
 export const saferFetch = withRetries(
     {
         maxAttempts: 5,
         backoff: attempt => attempt ** 2 * 5,
         retryOn: isRetriableFetchError
     },
-    fetchWithBodyClone
+    fetchWithRetriableStatuses
 )


### PR DESCRIPTION
## Summary
- **WEBSITE-31** — Retry Turso `502`/`503`/`504` in `saferFetch` and skip Sentry capture for exhausted `PrismaClientKnownRequestError` SERVER_ERROR blips on `profile.getUnique`
- **WEBSITE-32** — Drop standalone `prisma:client:operation` transactions in `beforeSendTransaction` (Turso latency flagged as slow DB query, not an app bug)
- **WEBSITE-1T** — Filter `SyntaxError: Unexpected token '{'` from minified chunks / bots (no `/src/` frames) via `shouldDropClientEvent` + `ignoreErrors`

## Test plan
- [x] `bun run lint`
- [ ] CI green
- [ ] After deploy: `is:unresolved project:website` → 0
- [ ] Deploy sync resolves WEBSITE-31, WEBSITE-32, WEBSITE-1T in `APP_VERSION` release


Made with [Cursor](https://cursor.com)