### PR TITLE
Skip expected Bungie profile errors in Sentry

### DIFF
--- a/src/services/bungie/BungieClient.ts
+++ b/src/services/bungie/BungieClient.ts
@@ -92,8 +92,11 @@ export default abstract class BaseBungieClient implements BungieClientProtocol {
         18, // InvalidParameters — bad membership/type combos on optional lookups (e.g. clans)
         217, // UserCannotResolveCentralAccount — player search miss
         686, // ClanNotFound
+        1600, // DestinyAccountAcquisitionFailure — no linked Destiny account
+        1601, // DestinyAccountNotFound — deleted/wrong-platform membership on profile
         1618, // DestinyUnexpectedError — Bungie-side 500, surfaced in UI as load failure
         1653, // PGCRNotFound
+        1665, // DestinyPrivacyRestriction — private profile
         1688 // DestinyDirectBabelClientTimeout
     ])
 }


### PR DESCRIPTION
## Summary
- **WEBSITE-1F** regressed with Bungie error **1601** (`DestinyAccountNotFound`) on `/profile/:destinyMembershipId` — not in `ExpectedErrorCodes`, so react-query reported it despite `shouldSkipCapture`
- Add **1600** (no linked Destiny account), **1601** (account not found), and **1665** (privacy restriction) to `BaseBungieClient.ExpectedErrorCodes`
- Same bucket already included handled codes (5 maintenance, 1618 Bungie blip, 8 bad params) — this closes the gap for profile lookups

## Test plan
- [x] `bun run lint` + `bun tsc`
- [ ] CI green
- [ ] After deploy: `is:unresolved project:website` → 0; WEBSITE-1F resolved in `APP_VERSION`


Made with [Cursor](https://cursor.com)