### PR TITLE
Fix WEBSITE-4 hydration crash on invalid route params

### DIFF
--- a/src/app/(profile)/profile/[destinyMembershipId]/page.tsx
+++ b/src/app/(profile)/profile/[destinyMembershipId]/page.tsx
@@ -113,12 +113,7 @@ export default async function Page({ params }: PageProps) {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     if (!isValidDestinyMembershipId(params.destinyMembershipId)) {
-        return {
-            robots: {
-                follow: true,
-                index: false
-            }
-        }
+        notFound()
     }
 
     const [profile, basic] = await Promise.all([

--- a/src/app/clan/[groupId]/page.tsx
+++ b/src/app/clan/[groupId]/page.tsx
@@ -28,12 +28,14 @@ export default async function Page({ params }: PageProps) {
 
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
     if (!isValidClanGroupId(params.groupId)) {
-        return {}
+        notFound()
     }
 
     const clan = await getClan(params.groupId)
 
-    if (!clan) return {}
+    if (!clan) {
+        notFound()
+    }
 
     const clanName = fixClanName(clan.detail.name)
 

--- a/src/app/clan/server.ts
+++ b/src/app/clan/server.ts
@@ -1,6 +1,5 @@
 import { getClanBannerSource } from "bungie-net-core/endpoints/Destiny2"
 import { getGroup } from "bungie-net-core/endpoints/GroupV2"
-import { notFound } from "next/navigation"
 import { BungiePlatformError } from "~/models/BungieAPIError"
 import ServerBungieClient from "~/services/bungie/ServerBungieClient"
 import { reactRequestDedupe } from "~/util/react-cache"
@@ -16,8 +15,6 @@ const clanClient = new ServerBungieClient({
     timeout: 6000
 })
 
-const expectedErrorCodes = [1, 7, 621, 622, 686]
-
 export const getClan = reactRequestDedupe(async (groupId: string) =>
     getGroup(clanClient, { groupId })
         .then(res => {
@@ -26,13 +23,7 @@ export const getClan = reactRequestDedupe(async (groupId: string) =>
             }
             return res.Response
         })
-        .catch(err => {
-            if (err instanceof BungiePlatformError && expectedErrorCodes.includes(err.ErrorCode)) {
-                notFound()
-            } else {
-                return null
-            }
-        })
+        .catch(() => null)
 )
 
 const bannerClient = new ServerBungieClient({

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,11 +1,7 @@
-"use client"
-
-import { PageWrapper } from "~/components/PageWrapper"
-
 export default function NotFound() {
     return (
-        <PageWrapper>
+        <div className="mx-auto mt-2 mb-6 w-[95%] lg:w-[90%] xl:w-[85%]">
             <h1>{"Not found :("}</h1>
-        </PageWrapper>
+        </div>
     )
 }

--- a/src/app/pgcr/[instanceId]/page.tsx
+++ b/src/app/pgcr/[instanceId]/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next"
+import { notFound } from "next/navigation"
 
 import { PageWrapper } from "~/components/PageWrapper"
 import PGCR from "~/components/pgcr/pgcr-view"
@@ -10,6 +11,7 @@ import {
     tryPrefetchActivity
 } from "~/lib/pgcr/server"
 import { type PGCRPageProps } from "~/lib/pgcr/types"
+import { isValidInstanceId } from "~/util/destiny/routeParams"
 
 export const revalidate = 0
 
@@ -24,19 +26,14 @@ export default async function Page({ params }: PGCRPageProps) {
 }
 
 export async function generateMetadata({ params }: PGCRPageProps): Promise<Metadata> {
-    if (!/^\d+$/.test(params.instanceId)) {
-        return {}
+    if (!isValidInstanceId(params.instanceId)) {
+        notFound()
     }
 
     const activity = await tryPrefetchActivity(params.instanceId)
 
     if (!activity) {
-        return {
-            robots: {
-                follow: true,
-                index: false
-            }
-        }
+        notFound()
     }
 
     const { idTitle, ogTitle, description } = getMetaData(activity)


### PR DESCRIPTION
## Summary
- **WEBSITE-4** (`Unknown root exit status` / React #329): `generateMetadata` returned `{}` or partial robots metadata while the page called `notFound()` for invalid clan/profile/PGCR params — RSC exit status mismatch caused client hydration to crash (e.g. `/clan/www.endgameleagues.com`).
- Align `generateMetadata` with page-level `notFound()` on clan, profile, and PGCR routes.
- Stop calling `notFound()` inside cached `getClan()` — page/metadata own the 404 boundary.
- Convert global `not-found.tsx` to a server component (no client `PageWrapper` boundary).

## Test plan
- [ ] `bun run lint` + `tsc`
- [ ] Visit `https://raidhub.io/clan/www.endgameleagues.com` — 404, no console hydration error
- [ ] Visit invalid profile URL with garbage suffix — 404, no hydration error
- [ ] Valid clan/profile/PGCR URLs still render normally
- [ ] Post-deploy: confirm WEBSITE-4 resolves in Sentry (`Fixes WEBSITE-4`)


Made with [Cursor](https://cursor.com)