### PR TITLE
Filter illegal lowman tags for Pantheon and Desert Perpetual

### DIFF
--- a/src/hooks/profile/useRaidTags.ts
+++ b/src/hooks/profile/useRaidTags.ts
@@ -1,6 +1,14 @@
 import type { Collection } from "@discordjs/collection"
 import { useCallback, useMemo } from "react"
 import { useRaidHubManifest } from "~/components/providers/RaidHubManifestManager"
+import {
+    PANTHEON_V1_NEZAREC_VERSION_ID,
+    PANTHEON_V1_ORYX_VERSION_ID,
+    PANTHEON_V1_RHULK_VERSION_ID,
+    PANTHEON_V2_CALUS_VERSION_ID,
+    PANTHEON_V2_INSURRECTION_VERSION_ID,
+    PANTHEON_V2_MORGETH_VERSION_ID
+} from "~/lib/manifest/pantheon"
 import { type RaidHubInstance, type RaidHubInstanceForPlayer } from "~/services/raidhub/types"
 import { includedIn } from "~/util/helpers"
 
@@ -133,14 +141,55 @@ const useGetWeight = () => {
 const soloTaniksFirst = new Date("2024-09-12T17:00:00Z")
 const trioFreshSalvationsEdgeAllowed = new Date("2025-01-01T00:00:00Z")
 
-function isIllegalTag({ activityId, dateCompleted }: RaidHubInstance, weight: number): boolean {
+function isIllegalTag(
+    { activityId, versionId, dateCompleted }: RaidHubInstance,
+    weight: number
+): boolean {
     switch (activityId) {
+        case 101:
+            // Oryx Exalted — solo fresh needs a second player
+            if (versionId === PANTHEON_V1_ORYX_VERSION_ID) {
+                return bitfieldMatches(weight, Solo | Fresh)
+            }
+            // Rhulk Indomitable — fresh lowman needs trio
+            if (versionId === PANTHEON_V1_RHULK_VERSION_ID) {
+                return bitfieldMatches(weight, Duo | Fresh)
+            }
+            // Nezarec Sublime — fresh lowman needs trio
+            if (versionId === PANTHEON_V1_NEZAREC_VERSION_ID) {
+                return bitfieldMatches(weight, Duo | Fresh)
+            }
+            return false
+        case 102:
+            if (!bitfieldMatches(weight, Solo)) {
+                return false
+            }
+            // Calus Resplendent — shadow realm plates require multiple players
+            if (versionId === PANTHEON_V2_CALUS_VERSION_ID) {
+                return true
+            }
+            // Morgeth Surpassing — ogre control and wipe recovery require multiple players
+            if (versionId === PANTHEON_V2_MORGETH_VERSION_ID) {
+                return true
+            }
+            // Insurrection Prime Revolutionary — map routing and capacitor duties require multiple players
+            if (versionId === PANTHEON_V2_INSURRECTION_VERSION_ID) {
+                return true
+            }
+            return false
         case 16:
             // epic desert perpetual - allow solo epic tags
             return false
         case 15:
-            // normal desert perpetual - don't allow solo tags
-            return bitfieldMatches(weight, Solo)
+            // fracturing encounter cannot be completed solo
+            if (bitfieldMatches(weight, Solo)) {
+                return true
+            }
+            // worldline mechanics still need a third player
+            if (bitfieldMatches(weight, Duo) && !bitfieldMatches(weight, Solo)) {
+                return true
+            }
+            return false
         case 14:
             // trio fresh - allow after 1/1/25
             return (

--- a/src/lib/manifest/pantheon.ts
+++ b/src/lib/manifest/pantheon.ts
@@ -2,6 +2,16 @@ import type { RaidHubManifestResponse, RaidHubVersionDefinition } from "~/servic
 
 export const PANTHEON_COMMUNITY_RACE_VERSION_ID = 134
 
+/** Pantheon v1 (activity 101) encounter version IDs. */
+export const PANTHEON_V1_ORYX_VERSION_ID = 129
+export const PANTHEON_V1_RHULK_VERSION_ID = 130
+export const PANTHEON_V1_NEZAREC_VERSION_ID = 131
+
+/** Pantheon v2 (activity 102) encounter version IDs. */
+export const PANTHEON_V2_CALUS_VERSION_ID = 132
+export const PANTHEON_V2_MORGETH_VERSION_ID = 133
+export const PANTHEON_V2_INSURRECTION_VERSION_ID = 134
+
 /** Pantheon checkpoint labels drop the trailing difficulty adjective, e.g. "Oryx Exalted" -> "Oryx". */
 export const getPantheonCheckpointName = (versionName: string): string | null => {
     const parts = versionName.trim().split(/\s+/).filter(Boolean)


### PR DESCRIPTION
## Summary
- Pantheon v1 (101): block fresh solo on Oryx (129); block fresh solo/duo on Rhulk (130) and Nezarec (131)
- Pantheon v2 (102): block solo on Calus (132), Morgeth (133), and Insurrection Prime (134)
- Desert Perpetual normal (15): block solo and duo Koregos tags separately

## Test plan
- [x] `bun run lint`
- [ ] Spot-check profile tags for Pantheon v1/v2 and normal DP lowmans on localhost or Vercel preview


Made with [Cursor](https://cursor.com)